### PR TITLE
FC-0001: rename toggle_warnings to toggle_warning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,8 @@ Change Log
 Unreleased
 ----------
 
+* Rename toggle_warnings to toggle_warning for consistency with setting_warning.
+
 [8.1.0] - 2022-01-28
 --------------------
 
@@ -35,7 +37,7 @@ Changed
 Changed
 ~~~~~~~
 
-* **BREAKING CHANGE:** Updated ``EnsureJWTAuthSettingsMiddleware`` to understand and work with permissions combined using DRF's in-built support. This allows switching away from ``rest_condition``. Any view that still uses ``rest_condition`` will cause the middleware to throw an error. 
+* **BREAKING CHANGE:** Updated ``EnsureJWTAuthSettingsMiddleware`` to understand and work with permissions combined using DRF's in-built support. This allows switching away from ``rest_condition``. Any view that still uses ``rest_condition`` will cause the middleware to throw an error.
 
 
 [7.0.1] - 2021-08-10

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -9,6 +9,6 @@ Application configuration constants and code.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-10-15
 # .. toggle_target_removal_date: 2019-12-31
-# .. toggle_warnings: This feature fixed ecommerce, but broke edx-platform. The toggle enables us to fix over time.
+# .. toggle_warning: This feature fixed ecommerce, but broke edx-platform. The toggle enables us to fix over time.
 # .. toggle_tickets: ARCH-1210, ARCH-1199, ARCH-1197
 ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE = 'ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE'


### PR DESCRIPTION
Rename toggle_warnings to toggle_warning for consistency with setting_warning.

Relates to: https://github.com/openedx/code-annotations/pull/80