### PR TITLE
docs: generalize "edx-search" to "search" in pagination docstring

### DIFF
--- a/edx_rest_framework_extensions/paginators.py
+++ b/edx_rest_framework_extensions/paginators.py
@@ -78,11 +78,11 @@ class NamespacedPageNumberPagination(pagination.PageNumberPagination):
 
 def paginate_search_results(object_class, search_results, page_size, page):
     """
-    Takes edx-search results and returns a Page object populated
+    Takes search results and returns a Page object populated
     with db objects for that page.
 
     :param object_class: Model class to use when querying the db for objects.
-    :param search_results: edX-search results.
+    :param search_results: search results.
     :param page_size: Number of results per page.
     :param page: Page number.
     :return: Paginator object with model objects


### PR DESCRIPTION
## Description

When this code was extracted from edx-platform,
it was likely used to paginate search results
specifically from the "edx-search" library
(http://github.com/openedx/edx-search/).

Now that this is generic utility function,
it makes more sense to just say
"search results" instead of
"edx-search results", as the
result list can come from any backend.

## Reviewers

@georgebabey , as the original author, do you mind reviewing this docs tweak?