### PR TITLE
feat: enhance get_decoded_jwt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,17 @@ Change Log
 Unreleased
 ----------
 
+
+[8.2.0] - 2022-06-15
+--------------------
+
+Changed
+~~~~~~~
+
 * Rename toggle_warnings to toggle_warning for consistency with setting_warning.
+* Enhanced get_decoded_jwt to also call get_decoded_jwt_from_auth,
+so it doesn't need to be called separately and can use the cached
+Jwt.
 
 [8.1.0] - 2022-01-28
 --------------------

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.1.0'  # pragma: no cover
+__version__ = '8.2.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/cookies.py
+++ b/edx_rest_framework_extensions/auth/jwt/cookies.py
@@ -2,9 +2,22 @@
 JWT Authentication cookie utilities.
 """
 
-from django.conf import settings
+import logging
 
+from django.conf import settings
+from edx_django_utils.monitoring import increment as increment_custom_attribute
+from edx_django_utils.monitoring import set_custom_attribute
+from rest_framework.request import Request as DrfRequest
+from rest_framework.settings import api_settings
+
+from edx_rest_framework_extensions.auth.jwt.authentication import (
+    JwtAuthentication,
+    get_decoded_jwt_from_auth,
+)
 from edx_rest_framework_extensions.auth.jwt.decoder import configured_jwt_decode_handler
+
+
+logger = logging.getLogger(__name__)
 
 
 def jwt_cookie_name():
@@ -23,11 +36,47 @@ def get_decoded_jwt(request):
     """
     Grab jwt from jwt cookie in request if possible.
 
+    Note: May return the decoded authorization header JWT in some cases.
+
     Returns a decoded jwt dict if it can be found.
     Returns None if the jwt is not found.
     """
-    jwt_cookie = request.COOKIES.get(jwt_cookie_name(), None)
+    # use cached jwt if it exists
+    decoded_jwt_from_auth = get_decoded_jwt_from_auth(request)
+    if decoded_jwt_from_auth:
+        return decoded_jwt_from_auth
 
+    # check if jwt cookie exists
+    jwt_cookie = request.COOKIES.get(jwt_cookie_name(), None)
     if not jwt_cookie:
         return None
-    return configured_jwt_decode_handler(jwt_cookie)
+
+    # Custom attribute can be used to determine priority of caching.
+    # Note: Not all IDAs may support increment_custom_attribute
+    set_custom_attribute('jwt_cookie_processed', True)
+    increment_custom_attribute('jwt_cookie_processed_count')
+
+    # .. toggle_name: DISABLE_NEW_JWT_COOKIE_PROCESSING
+    # .. toggle_implementation: DjangoSetting
+    # .. toggle_default: False
+    # .. toggle_description: Rollout toggle to disable the new Jwt cookie processing code, in case of a bug.
+    # .. toggle_use_cases: temporary
+    # .. toggle_creation_date: 2022-06-14
+    # .. toggle_target_removal_date: 2022-07-01
+    # .. toggle_tickets: ARCHBOM-2129
+    if getattr(settings, 'DISABLE_NEW_JWT_COOKIE_PROCESSING', False):
+        return configured_jwt_decode_handler(jwt_cookie)
+
+    try:
+        drf_request = request
+        if not isinstance(request, DrfRequest):
+            drf_request = DrfRequest(request, parsers=api_settings.DEFAULT_PARSER_CLASSES)
+        user_and_auth = JwtAuthentication().authenticate(drf_request)
+        if user_and_auth is not None:
+            return configured_jwt_decode_handler(user_and_auth[1])
+
+        logger.info('get_decoded_jwt: Failed to decode Jwt cookie.')
+    except Exception as ex:  # pylint: disable=broad-except
+        logger.info(f'get_decoded_jwt: Unknown error decoding Jwt cookie. {ex!r}')
+
+    return None

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_cookies.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_cookies.py
@@ -4,6 +4,7 @@ Unit tests for jwt cookies module.
 from unittest import mock
 
 import ddt
+from django.http import HttpRequest
 from django.test import TestCase, override_settings
 
 from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
@@ -37,6 +38,13 @@ class TestJwtAuthCookies(TestCase):
     def test_get_default_value(self, jwt_cookie_func, expected_default_value):
         self.assertEqual(jwt_cookie_func(), expected_default_value)
 
+    @mock.patch('edx_rest_framework_extensions.auth.jwt.cookies.get_decoded_jwt_from_auth', return_value='decoded.jwt')
+    def test_get_decoded_jwt_from_decoded_jwt_from_auth(self, _):
+        """Ensure get_decoded_jwt_from_auth is used as part of get_decoded_jwt."""
+        decoded_jwt = cookies.get_decoded_jwt(None)
+
+        self.assertEqual('decoded.jwt', decoded_jwt)
+
     def test_get_decoded_jwt_from_existing_cookie(self):
         user = UserFactory()
         payload = generate_latest_version_payload(user)
@@ -44,8 +52,47 @@ class TestJwtAuthCookies(TestCase):
         expected_decoded_jwt = jwt_decode_handler(jwt)
 
         mock_request_with_cookie = mock.Mock(COOKIES={'edx-jwt-cookie': jwt})
+        mock_request_with_cookie.__class__ = HttpRequest
 
         decoded_jwt = cookies.get_decoded_jwt(mock_request_with_cookie)
+
+        self.assertEqual(expected_decoded_jwt, decoded_jwt)
+
+    @mock.patch('edx_rest_framework_extensions.auth.jwt.cookies.logger')
+    def test_get_decoded_jwt_fails_with_broad_except(self, mock_logger):
+        user = UserFactory()
+        payload = generate_latest_version_payload(user)
+        jwt = generate_jwt_token(payload)
+
+        mock_request_with_cookie = mock.Mock(COOKIES={'edx-jwt-cookie': jwt})
+
+        # Fails because the request is a mock, and not a Django HttpRequest
+        self.assertIsNone(cookies.get_decoded_jwt(mock_request_with_cookie))
+
+        mock_logger.info.assert_called_once_with(
+            "get_decoded_jwt: Unknown error decoding Jwt cookie. AssertionError('The `request` argument must "
+            "be an instance of `django.http.HttpRequest`, not `unittest.mock.Mock`.')"
+        )
+
+    @override_settings(DISABLE_NEW_JWT_COOKIE_PROCESSING=True)
+    def test_get_decoded_jwt_legacy_success_with_mock_request(self):
+        """
+        Test legacy processing.
+
+        To be removed with DISABLE_NEW_JWT_COOKIE_PROCESSING.
+        """
+        user = UserFactory()
+        payload = generate_latest_version_payload(user)
+        jwt = generate_jwt_token(payload)
+
+        expected_decoded_jwt = jwt_decode_handler(jwt)
+
+        mock_request_with_cookie = mock.Mock(COOKIES={'edx-jwt-cookie': jwt})
+
+        decoded_jwt = cookies.get_decoded_jwt(mock_request_with_cookie)
+
+        # Note: This should succeed, where the newer logic would have failed because
+        #   the mock is not an HttpRequest. See test_get_decoded_jwt_fails_with_broad_except
         self.assertEqual(expected_decoded_jwt, decoded_jwt)
 
     def test_get_decoded_jwt_when_no_cookie(self):

--- a/test_settings.py
+++ b/test_settings.py
@@ -37,6 +37,8 @@ JWT_AUTH = {
 
     'JWT_AUDIENCE': 'test-aud',
 
+    'JWT_AUTH_COOKIE': 'edx-jwt-cookie',
+
     'JWT_DECODE_HANDLER': 'edx_rest_framework_extensions.auth.jwt.decoder.jwt_decode_handler',
 
     'JWT_ISSUER': 'test-iss',


### PR DESCRIPTION
**Description:**

The get_decoded_jwt will now also call get_decoded_jwt_from_auth,
so it doesn't need to be called separately and can use the cached
Jwt.

Also added monitoring custom attributes to determine if it is
worthwhile to add additional caching.

**JIRA:**

2U Private: ARCHBOM-2129

**Reviewers:**
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bump if needed
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)