### PR TITLE
feat: Error message when JWT user disabled

### DIFF
--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.2.0'  # pragma: no cover
+__version__ = '8.3.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -75,9 +75,7 @@ class JwtAuthentication(JSONWebTokenAuthentication):
             if user and isinstance(user, get_user_model()):
                 if not user.has_usable_password():
                     msg = 'User disabled by admin: %s' % user.get_username()
-                    raise exceptions.AuthenticationFailed({
-                        'error_code': JWT_USER_DISABLED_ERROR,
-                        'developer_message': msg})
+                    raise exceptions.AuthenticationFailed(code=JWT_USER_DISABLED_ERROR, detail=msg)
 
             # Not using JWT cookies, CSRF validation not required
             use_jwt_cookie_requested = request.META.get(USE_JWT_COOKIE_HEADER)

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -71,11 +71,8 @@ class JwtAuthentication(JSONWebTokenAuthentication):
                 return user_and_auth
 
             # Fail authentication if user disabled
-            try:
-                user = user_and_auth[0]
-            except IndexError:
-                user = None
-            if user:
+            user = user_and_auth[0]
+            if user and isinstance(user, get_user_model()):
                 if not user.has_usable_password():
                     msg = 'User disabled by admin: %s' % user.get_username()
                     raise exceptions.AuthenticationFailed({

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -71,9 +71,10 @@ class JwtAuthentication(JSONWebTokenAuthentication):
             user = user_and_auth[0]
             if user and isinstance(user, get_user_model()):
                 if not user.has_usable_password():
-                    msg = 'User is disabled.'
-                    logger.exception(msg)
-                    raise exceptions.AuthenticationFailed(msg)
+                    log_message = 'User id {} attempted JWT authentication after being disabled by ' \
+                                  'an admin.'.format(user.id)
+                    logger.exception(log_message)
+                    raise exceptions.AuthenticationFailed('User is disabled.')
 
             # Not using JWT cookies, CSRF validation not required
             use_jwt_cookie_requested = request.META.get(USE_JWT_COOKIE_HEADER)

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -75,7 +75,11 @@ class JwtAuthentication(JSONWebTokenAuthentication):
             if user and isinstance(user, get_user_model()):
                 if not user.has_usable_password():
                     msg = 'User disabled by admin: %s' % user.get_username()
-                    raise exceptions.AuthenticationFailed(code=JWT_USER_DISABLED_ERROR, detail=msg)
+                    response = {
+                        'error_code': JWT_USER_DISABLED_ERROR,
+                        'developer_message': msg
+                    }
+                    raise exceptions.AuthenticationFailed(detail=response, code=JWT_USER_DISABLED_ERROR)
 
             # Not using JWT cookies, CSRF validation not required
             use_jwt_cookie_requested = request.META.get(USE_JWT_COOKIE_HEADER)

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -14,9 +14,6 @@ from edx_rest_framework_extensions.auth.jwt.decoder import configured_jwt_decode
 from edx_rest_framework_extensions.settings import get_setting
 
 
-JWT_USER_DISABLED_ERROR = 'user_is_disabled'
-
-
 logger = logging.getLogger(__name__)
 
 
@@ -74,12 +71,9 @@ class JwtAuthentication(JSONWebTokenAuthentication):
             user = user_and_auth[0]
             if user and isinstance(user, get_user_model()):
                 if not user.has_usable_password():
-                    msg = 'User disabled by admin: %s' % user.get_username()
-                    response = {
-                        'error_code': JWT_USER_DISABLED_ERROR,
-                        'developer_message': msg
-                    }
-                    raise exceptions.AuthenticationFailed(detail=response, code=JWT_USER_DISABLED_ERROR)
+                    msg = 'User is disabled.'
+                    logger.exception(msg)
+                    raise exceptions.AuthenticationFailed(msg)
 
             # Not using JWT cookies, CSRF validation not required
             use_jwt_cookie_requested = request.META.get(USE_JWT_COOKIE_HEADER)

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
@@ -9,10 +9,7 @@ from rest_framework.exceptions import AuthenticationFailed, PermissionDenied
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
 from edx_rest_framework_extensions.auth.jwt import authentication
-from edx_rest_framework_extensions.auth.jwt.authentication import (
-    JWT_USER_DISABLED_ERROR,
-    JwtAuthentication,
-)
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from edx_rest_framework_extensions.auth.jwt.constants import USE_JWT_COOKIE_HEADER
 from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
 from edx_rest_framework_extensions.auth.jwt.tests.utils import (
@@ -212,7 +209,7 @@ class JwtAuthenticationTests(TestCase):
             with mock.patch.object(User, 'has_usable_password', return_value=False):
                 with self.assertRaises(AuthenticationFailed) as auth_failure:
                     JwtAuthentication().authenticate(request)
-                self.assertEqual(auth_failure.exception.detail.get('error_code').code, JWT_USER_DISABLED_ERROR)
+                self.assertEqual(auth_failure.exception.detail, 'User is disabled.')
 
     @ddt.data(True, False)
     def test_get_decoded_jwt_from_auth(self, is_jwt_authentication):

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
@@ -9,7 +9,10 @@ from rest_framework.exceptions import AuthenticationFailed, PermissionDenied
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
 from edx_rest_framework_extensions.auth.jwt import authentication
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication, JWT_USER_DISABLED_ERROR
+from edx_rest_framework_extensions.auth.jwt.authentication import (
+    JWT_USER_DISABLED_ERROR,
+    JwtAuthentication,
+)
 from edx_rest_framework_extensions.auth.jwt.constants import USE_JWT_COOKIE_HEADER
 from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
 from edx_rest_framework_extensions.auth.jwt.tests.utils import (

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
@@ -197,13 +197,10 @@ class JwtAuthenticationTests(TestCase):
         )
 
     def test_authenticate_with_disabled_user(self):
-        """"""
+        """ Verify an AuthenticationFailed exception is raised if user is disabled. """
         jwt_token = self._get_test_jwt_token()
         request = RequestFactory().get('/', HTTP_AUTHORIZATION=jwt_token)
-
-        username = 'ckramer'
-        email = 'ckramer@hotmail.com'
-        user = factories.UserFactory(email=email, username=username, is_staff=False)
+        user = factories.UserFactory()
 
         with mock.patch.object(JSONWebTokenAuthentication, 'authenticate', return_value=(user, "mock-auth")):
             with mock.patch.object(User, 'has_usable_password', return_value=False):

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
@@ -210,9 +210,9 @@ class JwtAuthenticationTests(TestCase):
 
         with mock.patch.object(JSONWebTokenAuthentication, 'authenticate', return_value=(user, "mock-auth")):
             with mock.patch.object(User, 'has_usable_password', return_value=False):
-                with self.assertRaises(AuthenticationFailed) as auth_failed_exception:
+                with self.assertRaises(AuthenticationFailed) as auth_failure:
                     JwtAuthentication().authenticate(request)
-                self.assertEqual(auth_failed_exception.exception.detail.code, JWT_USER_DISABLED_ERROR)
+                self.assertEqual(auth_failure.exception.detail.get('error_code').code, JWT_USER_DISABLED_ERROR)
 
     @ddt.data(True, False)
     def test_get_decoded_jwt_from_auth(self, is_jwt_authentication):

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
@@ -9,7 +9,7 @@ from rest_framework.exceptions import AuthenticationFailed, PermissionDenied
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
 from edx_rest_framework_extensions.auth.jwt import authentication
-from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
+from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication, JWT_USER_DISABLED_ERROR
 from edx_rest_framework_extensions.auth.jwt.constants import USE_JWT_COOKIE_HEADER
 from edx_rest_framework_extensions.auth.jwt.decoder import jwt_decode_handler
 from edx_rest_framework_extensions.auth.jwt.tests.utils import (
@@ -207,8 +207,9 @@ class JwtAuthenticationTests(TestCase):
 
         with mock.patch.object(JSONWebTokenAuthentication, 'authenticate', return_value=(user, "mock-auth")):
             with mock.patch.object(User, 'has_usable_password', return_value=False):
-                with self.assertRaises(AuthenticationFailed):
+                with self.assertRaises(AuthenticationFailed) as auth_failed_exception:
                     JwtAuthentication().authenticate(request)
+                self.assertEqual(auth_failed_exception.exception.detail.code, JWT_USER_DISABLED_ERROR)
 
     @ddt.data(True, False)
     def test_get_decoded_jwt_from_auth(self, is_jwt_authentication):

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
@@ -196,14 +196,6 @@ class JwtAuthenticationTests(TestCase):
             "Exception:PermissionDenied('CSRF Failed: CSRF cookie not set.')",
         )
 
-    def test_authenticate_no_user_returned(self):
-        """"""
-        jwt_token = self._get_test_jwt_token()
-        request = RequestFactory().get('/', HTTP_AUTHORIZATION=jwt_token)
-
-        with mock.patch.object(JSONWebTokenAuthentication, 'authenticate', return_value=(None, "mock-auth")):
-            JwtAuthentication().authenticate(request)
-
     def test_authenticate_with_disabled_user(self):
         """"""
         jwt_token = self._get_test_jwt_token()


### PR DESCRIPTION
**Description:**

If user has been disabled by admin, JWT Token Authentication should fail with appropriate message.
Disabled user refers to user's password being set as unusable by admin on page `/support/manage_user`

**JIRA:**

[LEARNER-9001](https://2u-internal.atlassian.net/browse/LEARNER-9001)

**Additional Details**

* **Dependencies:**: None
* **Merge deadline:** August 19th 2022
* **Author concerns:** None

**Testing instructions:**
* Fetch JWT token for an edx user.
* Call the api `/api/mobile/v1/users/honor/course_enrollments/` with the JWT token.
* See that response is received.
* Disable the user from the page `/support/manage_user`.
* Call api again with same user.
* Observe authentication failed error `User disabled by admin: <username>`


**Reviewers:**
- [@jawad-khan  ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bump if needed
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
