### PR TITLE
feat: Raise exception decoding symmetric jwt if flag is false

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,14 @@ Change Log
 Unreleased
 ----------
 
+[8.1.1] - 2022-08-24
+--------------------
+
+Added
+~~~~~
+
+* Added only asymmetric jwt decoding functionality in decoder
+
 * Rename toggle_warnings to toggle_warning for consistency with setting_warning.
 
 [8.1.0] - 2022-01-28

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,13 +12,16 @@ Change Log
 Unreleased
 ----------
 
-[8.1.1] - 2022-08-24
+[8.2.0] - 2022-08-24
 --------------------
 
 Added
 ~~~~~
 
 * Added only asymmetric jwt decoding functionality in decoder
+
+Changed
+~~~~~~~
 
 * Rename toggle_warnings to toggle_warning for consistency with setting_warning.
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.1.0'  # pragma: no cover
+__version__ = '8.1.1'  # pragma: no cover

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.1.1'  # pragma: no cover
+__version__ = '8.2.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -183,7 +183,7 @@ def is_jwt_authenticated(request):
     return True
 
 
-def get_decoded_jwt_from_auth(request):
+def get_decoded_jwt_from_auth(request, decode_symmetric_token=True):
     """
     Grab jwt from request.auth in request if possible.
 
@@ -193,4 +193,4 @@ def get_decoded_jwt_from_auth(request):
     if not is_jwt_authenticated(request):
         return None
 
-    return configured_jwt_decode_handler(request.auth)
+    return configured_jwt_decode_handler(request.auth, decode_symmetric_token)

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -183,7 +183,7 @@ def is_jwt_authenticated(request):
     return True
 
 
-def get_decoded_jwt_from_auth(request, decode_symmetric_token=True):
+def get_decoded_jwt_from_auth(request):
     """
     Grab jwt from request.auth in request if possible.
 
@@ -193,4 +193,4 @@ def get_decoded_jwt_from_auth(request, decode_symmetric_token=True):
     if not is_jwt_authenticated(request):
         return None
 
-    return configured_jwt_decode_handler(request.auth, decode_symmetric_token)
+    return configured_jwt_decode_handler(request.auth)

--- a/edx_rest_framework_extensions/auth/jwt/decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/decoder.py
@@ -35,6 +35,8 @@ def jwt_decode_handler(token, decode_symmetric_token=True):
     Notes:
         * Requires "exp" and "iat" claims to be present in the token's payload.
         * Aids debugging by logging InvalidTokenError log entries when decoding fails.
+        * Setting for JWT_DECODE_HANDLER expects a single argument, token. The new argument i.e. decode_symmetric_token
+          is for internal use only.
 
     Examples:
         Use with `djangorestframework-jwt <https://getblimp.github.io/django-rest-framework-jwt/>`_, by changing
@@ -71,12 +73,26 @@ def jwt_decode_handler(token, decode_symmetric_token=True):
     return _set_token_defaults(decoded_token)
 
 
-def configured_jwt_decode_handler(token, decode_symmetric_token=True):
+def configured_jwt_decode_handler(token):
     """
     Calls the ``jwt_decode_handler`` configured in the ``JWT_DECODE_HANDLER`` setting.
     """
     api_setting_jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
-    return api_setting_jwt_decode_handler(token, decode_symmetric_token)
+    return api_setting_jwt_decode_handler(token)
+
+
+def get_asymmetric_only_jwt_decode_handler(token):
+    """
+    Returns a jwt_decode_handler that will only validate asymmetrically signed JWTs.
+
+    WARNING: This will only work with a service that is configured to use the
+       jwt_decode_handler from this library. This can be used to decode an
+       already decoded JWT, to ensure it is asymmetrically signed. This check
+       can go away once the DEPR for symmetrically signed JWTs is complete:
+       https://github.com/openedx/public-engineering/issues/83
+    """
+    api_setting_jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
+    return api_setting_jwt_decode_handler(token, decode_symmetric_token=False)
 
 
 def decode_jwt_scopes(token):

--- a/edx_rest_framework_extensions/auth/jwt/decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/decoder.py
@@ -35,7 +35,7 @@ def jwt_decode_handler(token, decode_symmetric_token=True):
     Notes:
         * Requires "exp" and "iat" claims to be present in the token's payload.
         * Aids debugging by logging InvalidTokenError log entries when decoding fails.
-        * Setting for JWT_DECODE_HANDLER expects a single argument, token. The new argument i.e. decode_symmetric_token
+        * Setting for JWT_DECODE_HANDLER expects a single argument, token. The argument decode_symmetric_token
           is for internal use only.
 
     Examples:
@@ -91,8 +91,7 @@ def get_asymmetric_only_jwt_decode_handler(token):
        can go away once the DEPR for symmetrically signed JWTs is complete:
        https://github.com/openedx/public-engineering/issues/83
     """
-    api_setting_jwt_decode_handler = api_settings.JWT_DECODE_HANDLER
-    return api_setting_jwt_decode_handler(token, decode_symmetric_token=False)
+    return jwt_decode_handler(token, decode_symmetric_token=False)
 
 
 def decode_jwt_scopes(token):

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
@@ -15,6 +15,7 @@ from edx_rest_framework_extensions.auth.jwt.decoder import (
     jwt_decode_handler,
 )
 from edx_rest_framework_extensions.auth.jwt.tests.utils import (
+    generate_asymmetric_jwt_token,
     generate_jwt_token,
     generate_latest_version_payload,
     generate_unversioned_payload,
@@ -191,18 +192,12 @@ class JWTDecodeHandlerTests(TestCase):
 
             patched_log.exception.assert_any_call("Token verification failed.")
 
-    def test_failure_decode_asymmetric(self):
+    def test_success_asymmetric_jwt_decode(self):
         """
-        Verifies the function logs decode failures when provided a symmetric token to asymmetric decode method,
-        and raises an InvalidTokenError if token is symmetric
+        Validates that a valid asymmetric token is properly decoded
         """
-        # Create valid token symmetric jwt token and use asymmetric method to decode.
-        with mock.patch('edx_rest_framework_extensions.auth.jwt.decoder.logger') as patched_log:
-            with self.assertRaises(jwt.InvalidTokenError):
-                token = generate_jwt_token(self.payload)
-                get_asymmetric_only_jwt_decode_handler(token)
-
-            patched_log.exception.assert_any_call("Token verification failed.")
+        token = generate_asymmetric_jwt_token(self.payload)
+        self.assertEqual(get_asymmetric_only_jwt_decode_handler(token), self.payload)
 
 
 def _jwt_decode_handler_with_defaults(token):  # pylint: disable=unused-argument

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
@@ -177,8 +177,21 @@ class JWTDecodeHandlerTests(TestCase):
             # Decode to see if MissingRequiredClaimError exception is raised or not
             jwt_decode_handler(token)
 
+    def test_failure_decode_symmetric_set_as_False(self):
+        """
+        Verifies the function logs decode failures with symmetric tken set as false,
+        and raises an InvalidTokenError if token is symmetric
+        """
+        # Create valid token symmetric jwt token and set decode_symmetric_token as False .
+        with mock.patch('edx_rest_framework_extensions.auth.jwt.decoder.logger') as patched_log:
+            with self.assertRaises(jwt.InvalidTokenError):
+                token = generate_jwt_token(self.payload)
+                jwt_decode_handler(token, decode_symmetric_token=False)
 
-def _jwt_decode_handler_with_defaults(token):  # pylint: disable=unused-argument
+            patched_log.exception.assert_any_call("Token verification failed.")
+
+
+def _jwt_decode_handler_with_defaults(token, decode_symmetric_token):  # pylint: disable=unused-argument
     """
     Accepts anything as a token and returns a fake JWT payload with defaults.
     """
@@ -189,7 +202,7 @@ def _jwt_decode_handler_with_defaults(token):  # pylint: disable=unused-argument
     }
 
 
-def _jwt_decode_handler_no_defaults(token):  # pylint: disable=unused-argument
+def _jwt_decode_handler_no_defaults(token, decode_symmetric_token):  # pylint: disable=unused-argument
     """
     Accepts anything as a token and returns a fake JWT payload with no defaults.
     """

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
@@ -191,7 +191,7 @@ class JWTDecodeHandlerTests(TestCase):
             patched_log.exception.assert_any_call("Token verification failed.")
 
 
-def _jwt_decode_handler_with_defaults(token, decode_symmetric_token):  # pylint: disable=unused-argument
+def _jwt_decode_handler_with_defaults(token):  # pylint: disable=unused-argument
     """
     Accepts anything as a token and returns a fake JWT payload with defaults.
     """
@@ -202,7 +202,7 @@ def _jwt_decode_handler_with_defaults(token, decode_symmetric_token):  # pylint:
     }
 
 
-def _jwt_decode_handler_no_defaults(token, decode_symmetric_token):  # pylint: disable=unused-argument
+def _jwt_decode_handler_no_defaults(token):  # pylint: disable=unused-argument
     """
     Accepts anything as a token and returns a fake JWT payload with no defaults.
     """

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
@@ -11,6 +11,7 @@ from edx_rest_framework_extensions.auth.jwt.decoder import (
     decode_jwt_filters,
     decode_jwt_is_restricted,
     decode_jwt_scopes,
+    get_asymmetric_only_jwt_decode_handler,
     jwt_decode_handler,
 )
 from edx_rest_framework_extensions.auth.jwt.tests.utils import (
@@ -179,14 +180,27 @@ class JWTDecodeHandlerTests(TestCase):
 
     def test_failure_decode_symmetric_set_as_False(self):
         """
-        Verifies the function logs decode failures with symmetric tken set as false,
+        Verifies the function logs decode failures with symmetric token set as false,
         and raises an InvalidTokenError if token is symmetric
         """
-        # Create valid token symmetric jwt token and set decode_symmetric_token as False .
+        # Create valid token symmetric jwt token and set decode_symmetric_token as False.
         with mock.patch('edx_rest_framework_extensions.auth.jwt.decoder.logger') as patched_log:
             with self.assertRaises(jwt.InvalidTokenError):
                 token = generate_jwt_token(self.payload)
                 jwt_decode_handler(token, decode_symmetric_token=False)
+
+            patched_log.exception.assert_any_call("Token verification failed.")
+
+    def test_failure_decode_asymmetric(self):
+        """
+        Verifies the function logs decode failures when provided a symmetric token to asymmetric decode method,
+        and raises an InvalidTokenError if token is symmetric
+        """
+        # Create valid token symmetric jwt token and use asymmetric method to decode.
+        with mock.patch('edx_rest_framework_extensions.auth.jwt.decoder.logger') as patched_log:
+            with self.assertRaises(jwt.InvalidTokenError):
+                token = generate_jwt_token(self.payload)
+                get_asymmetric_only_jwt_decode_handler(token)
 
             patched_log.exception.assert_any_call("Token verification failed.")
 

--- a/edx_rest_framework_extensions/auth/jwt/tests/utils.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/utils.py
@@ -2,6 +2,9 @@
 from time import time
 
 import jwt
+import json
+from jwkest import jwk
+from jwkest.jws import JWS
 from django.conf import settings
 
 
@@ -24,6 +27,20 @@ def generate_jwt_token(payload, signing_key=None):
     """
     signing_key = signing_key or settings.JWT_AUTH['JWT_ISSUERS'][0]['SECRET_KEY']
     return jwt.encode(payload, signing_key)
+
+
+def generate_asymmetric_jwt_token(payload):
+    """
+    Generate a valid asymmetric JWT token for authenticated requests.
+    """
+    keys = jwk.KEYS()
+    serialized_keypair = json.loads(settings.JWT_AUTH['JWT_PRIVATE_SIGNING_JWK'])
+    keys.add(serialized_keypair)
+    algorithm = settings.JWT_AUTH['JWT_SIGNING_ALGORITHM']
+
+    data = json.dumps(payload)
+    jws = JWS(data, alg=algorithm)
+    return jws.sign_compact(keys=keys)
 
 
 def generate_latest_version_payload(user, scopes=None, filters=None, version=None,

--- a/edx_rest_framework_extensions/auth/jwt/tests/utils.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/utils.py
@@ -1,11 +1,11 @@
 """ Utility functions for tests. """
+import json
 from time import time
 
 import jwt
-import json
+from django.conf import settings
 from jwkest import jwk
 from jwkest.jws import JWS
-from django.conf import settings
 
 
 def generate_jwt(user, scopes=None, filters=None, is_restricted=None):

--- a/test_settings.py
+++ b/test_settings.py
@@ -45,6 +45,29 @@ JWT_AUTH = {
 
     'JWT_SECRET_KEY': 'test-key',
 
+    'JWT_PUBLIC_SIGNING_JWK_SET': (
+        '{"keys": [{"kid": "BTZ9HA6K", "e": "AQAB", "kty": "RSA", "n": "o5cn3ljSRi6FaDEKTn0PS-oL9EFyv1pI7dRgffQLD1qf5D6'
+        'sprmYfWWokSsrWig8u2y0HChSygR6Jn5KXBqQn6FpM0dDJLnWQDRXHLl3Ey1iPYgDSmOIsIGrV9ZyNCQwk03wAgWbfdBTig3QSDYD-sTNOs3pc'
+        '4UD_PqAvU2nz_1SS2ZiOwOn5F6gulE1L0iE3KEUEvOIagfHNVhz0oxa_VRZILkzV-zr6R_TW1m97h4H8jXl_VJyQGyhMGGypuDrQ9_vaY_RLEu'
+        'lLCyY0INglHWQ7pckxBtI5q55-Vio2wgewe2_qYcGsnBGaDNbySAsvYcWRrqDiFyzrJYivodqTQ"}]}'
+    ),
+
+    'JWT_PRIVATE_SIGNING_JWK': (
+        '{"e": "AQAB", "d": "HIiV7KNjcdhVbpn3KT-I9n3JPf5YbGXsCIedmPqDH1d4QhBofuAqZ9zebQuxkRUpmqtYMv0Zi6ECSUqH387GYQF_Xv'
+        'FUFcjQRPycISd8TH0DAKaDpGr-AYNshnKiEtQpINhcP44I1AYNPCwyoxXA1fGTtmkKChsuWea7o8kytwU5xSejvh5-jiqu2SF4GEl0BEXIAPZs'
+        'gbzoPIWNxgO4_RzNnWs6nJZeszcaDD0CyezVSuH9QcI6g5QFzAC_YuykSsaaFJhZ05DocBsLczShJ9Omf6PnK9xlm26I84xrEh_7x4fVmNBg3x'
+        'WTLh8qOnHqGko93A1diLRCrKHOvnpvgQ", "n": "o5cn3ljSRi6FaDEKTn0PS-oL9EFyv1pI7dRgffQLD1qf5D6sprmYfWWokSsrWig8u2y0H'
+        'ChSygR6Jn5KXBqQn6FpM0dDJLnWQDRXHLl3Ey1iPYgDSmOIsIGrV9ZyNCQwk03wAgWbfdBTig3QSDYD-sTNOs3pc4UD_PqAvU2nz_1SS2ZiOwO'
+        'n5F6gulE1L0iE3KEUEvOIagfHNVhz0oxa_VRZILkzV-zr6R_TW1m97h4H8jXl_VJyQGyhMGGypuDrQ9_vaY_RLEulLCyY0INglHWQ7pckxBtI5'
+        'q55-Vio2wgewe2_qYcGsnBGaDNbySAsvYcWRrqDiFyzrJYivodqTQ", "q": "3T3DEtBUka7hLGdIsDlC96Uadx_q_E4Vb1cxx_4Ss_wGp1Lo'
+        'z3N3ZngGyInsKlmbBgLo1Ykd6T9TRvRNEWEtFSOcm2INIBoVoXk7W5RuPa8Cgq2tjQj9ziGQ08JMejrPlj3Q1wmALJr5VTfvSYBu0WkljhKNCy'
+        '1KB6fCby0C9WE", "p": "vUqzWPZnDG4IXyo-k5F0bHV0BNL_pVhQoLW7eyFHnw74IOEfSbdsMspNcPSFIrtgPsn7981qv3lN_staZ6JflKfH'
+        'ayjB_lvltHyZxfl0dvruShZOx1N6ykEo7YrAskC_qxUyrIvqmJ64zPW3jkuOYrFs7Ykj3zFx3Zq1H5568G0", "kid": "BTZ9HA6K", "kty"'
+        ': "RSA"}'
+    ),
+
+    'JWT_SIGNING_ALGORITHM': 'RS512',
+
     'JWT_SUPPORTED_VERSION': '1.0.0',
 
     'JWT_VERIFY_AUDIENCE': False,


### PR DESCRIPTION
Raise exception decoding symmetric jwt if decode_symmetric_token is false

**Description:**

By default jwt_decode_handler will decode symmetric tokens but if we pass decode_symmetric_token as False,
it will raise InvalidTokenError with NoSuitableSigningKeys in __cause__ attr of the exxception. Caller can determine whether the
exception was because of NoSuitableSigningKeys or something else went wrong.

**JIRA:**

[LEARNER-8941](https://2u-internal.atlassian.net/browse/LEARNER-8941)

**Additional Details**

* **Dependencies:**: None.

**Reviewers:**
- [x] tag reviewer

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bump if needed
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
