### PR TITLE
Revert "feat: Error message when JWT user disabled (#268)"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,22 @@ Change Log
 Unreleased
 ----------
 
+[8.3.1] - 2022-09-09
+--------------------
+
+Fixed
+~~~~~~~
+
+* Fixed disabled user error by reverting change to JwtAuthentication.
+
+[8.3.0] - 2022-09-07
+--------------------
+
+Changed
+~~~~~~~
+
+* JwtAuthentication will fail for disabled users (with unusable password).
+
 [8.2.0] - 2022-08-24
 --------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.3.0'  # pragma: no cover
+__version__ = '8.3.1'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -67,15 +67,6 @@ class JwtAuthentication(JSONWebTokenAuthentication):
             if not user_and_auth:
                 return user_and_auth
 
-            # Fail authentication if user disabled
-            user = user_and_auth[0]
-            if user and isinstance(user, get_user_model()):
-                if not user.has_usable_password():
-                    log_message = 'User id {} attempted JWT authentication after being disabled by ' \
-                                  'an admin.'.format(user.id)
-                    logger.exception(log_message)
-                    raise exceptions.AuthenticationFailed('User is disabled.')
-
             # Not using JWT cookies, CSRF validation not required
             use_jwt_cookie_requested = request.META.get(USE_JWT_COOKIE_HEADER)
             if not use_jwt_cookie_requested:

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
@@ -177,16 +177,11 @@ class JwtAuthenticationTests(TestCase):
     @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
     def test_authenticate_csrf_protected(self, mock_set_custom_attribute):
         """ Verify authenticate exception for CSRF protected cases. """
-
-        username = 'ckramer'
-        email = 'ckramer@hotmail.com'
-        user = factories.UserFactory(email=email, username=username, is_staff=False)
-
         request = RequestFactory().post('/')
 
         request.META[USE_JWT_COOKIE_HEADER] = 'true'
 
-        with mock.patch.object(JSONWebTokenAuthentication, 'authenticate', return_value=(user, "mock-auth")):
+        with mock.patch.object(JSONWebTokenAuthentication, 'authenticate', return_value=('mock-user', "mock-auth")):
             with self.assertRaises(PermissionDenied) as context_manager:
                 JwtAuthentication().authenticate(request)
 
@@ -195,18 +190,6 @@ class JwtAuthenticationTests(TestCase):
             'jwt_auth_failed',
             "Exception:PermissionDenied('CSRF Failed: CSRF cookie not set.')",
         )
-
-    def test_authenticate_with_disabled_user(self):
-        """ Verify an AuthenticationFailed exception is raised if user is disabled. """
-        jwt_token = self._get_test_jwt_token()
-        request = RequestFactory().get('/', HTTP_AUTHORIZATION=jwt_token)
-        user = factories.UserFactory()
-
-        with mock.patch.object(JSONWebTokenAuthentication, 'authenticate', return_value=(user, "mock-auth")):
-            with mock.patch.object(User, 'has_usable_password', return_value=False):
-                with self.assertRaises(AuthenticationFailed) as auth_failure:
-                    JwtAuthentication().authenticate(request)
-                self.assertEqual(auth_failure.exception.detail, 'User is disabled.')
 
     @ddt.data(True, False)
     def test_get_decoded_jwt_from_auth(self, is_jwt_authentication):


### PR DESCRIPTION
**Description:**

This reverts commit d483e6651b584ff787bc9678dc5237264145c281.

There were unintended consequences (errors) for checking disabled user in JwtAuthentication.

**Reviewers:**
- [ ] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bump if needed
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
