### PR TITLE
feat: add enduser.id custom attribute for monitoring

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,14 @@ Change Log
 Unreleased
 ----------
 
+[8.4.0] - 2022-12-16
+--------------------
+
+Added
+~~~~~
+
+* Added custom attribute enduser.id, following OpenTelemetry convention. This works with some New Relic automatic tooling around users. The old custom attribute request_user_id should be considered deprecated.
+
 [8.3.1] - 2022-09-09
 --------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.3.1'  # pragma: no cover
+__version__ = '8.4.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/middleware.py
+++ b/edx_rest_framework_extensions/middleware.py
@@ -98,12 +98,17 @@ class RequestCustomAttributesMiddleware(MiddlewareMixin):
 
     def _set_request_user_id_attribute(self, request):
         """
-        Add request_user_id custom attribute
-
-        Custom Attributes:
-             request_user_id
+        Add enduser.id (and request_user_id) custom attributes.
         """
         if hasattr(request, 'user') and hasattr(request.user, 'id') and request.user.id:
+            # .. custom_attribute_name: enduser.id
+            # .. custom_attribute_description: The user's id when available. The name enduser.id is an
+            #   OpenTelemetry convention that works with some of New Relic's tooling. See
+            #   https://docs.newrelic.com/docs/errors-inbox/error-users-impacted/
+            monitoring.set_custom_attribute('enduser.id', request.user.id)
+            # .. custom_attribute_name: request_user_id
+            # .. custom_attribute_description: The user's id when available. This duplicates enduser.id,
+            #   and could be deprecated/removed.
             monitoring.set_custom_attribute('request_user_id', request.user.id)
 
     def _set_request_referer_attribute(self, request):

--- a/edx_rest_framework_extensions/tests/test_middleware.py
+++ b/edx_rest_framework_extensions/tests/test_middleware.py
@@ -116,20 +116,26 @@ class TestRequestCustomAttributesMiddleware(TestCase):
         self.request.user = UserFactory()
 
         self.middleware.process_response(self.request, None)
-        mock_set_custom_attribute.assert_any_call('request_user_id', self.request.user.id)
-        mock_set_custom_attribute.assert_any_call(
-            'request_authenticated_user_found_in_middleware', 'process_response'
-        )
+
+        expected_calls = [
+            call('enduser.id', self.request.user.id),
+            call('request_user_id', self.request.user.id),
+            call('request_authenticated_user_found_in_middleware', 'process_response'),
+        ]
+        mock_set_custom_attribute.assert_has_calls(expected_calls, any_order=True)
 
     @patch('edx_django_utils.monitoring.set_custom_attribute')
     def test_request_user_id_attribute_with_exception(self, mock_set_custom_attribute):
         self.request.user = UserFactory()
 
         self.middleware.process_exception(self.request, None)
-        mock_set_custom_attribute.assert_any_call('request_user_id', self.request.user.id)
-        mock_set_custom_attribute.assert_any_call(
-            'request_authenticated_user_found_in_middleware', 'process_exception'
-        )
+
+        expected_calls = [
+            call('enduser.id', self.request.user.id),
+            call('request_user_id', self.request.user.id),
+            call('request_authenticated_user_found_in_middleware', 'process_exception'),
+        ]
+        mock_set_custom_attribute.assert_has_calls(expected_calls, any_order=True)
 
     @patch('edx_django_utils.monitoring.set_custom_attribute')
     def test_authenticated_user_found_in_process_request(self, mock_set_custom_attribute):

--- a/edx_rest_framework_extensions/tests/test_middleware.py
+++ b/edx_rest_framework_extensions/tests/test_middleware.py
@@ -112,7 +112,7 @@ class TestRequestCustomAttributesMiddleware(TestCase):
         mock_set_custom_attribute.assert_any_call('request_auth_type_guess', 'session-or-other')
 
     @patch('edx_django_utils.monitoring.set_custom_attribute')
-    def test_request_user_id_attribute(self, mock_set_custom_attribute):
+    def test_enduser_id_attribute(self, mock_set_custom_attribute):
         self.request.user = UserFactory()
 
         self.middleware.process_response(self.request, None)
@@ -125,7 +125,7 @@ class TestRequestCustomAttributesMiddleware(TestCase):
         mock_set_custom_attribute.assert_has_calls(expected_calls, any_order=True)
 
     @patch('edx_django_utils.monitoring.set_custom_attribute')
-    def test_request_user_id_attribute_with_exception(self, mock_set_custom_attribute):
+    def test_enduser_id_attribute_with_exception(self, mock_set_custom_attribute):
         self.request.user = UserFactory()
 
         self.middleware.process_exception(self.request, None)


### PR DESCRIPTION
**Description:**

Added custom attribute enduser.id, following OpenTelemetry convention. The old custom attribute request_user_id should be considered deprecated. This works with some New Relic automatic tooling around users. See https://docs.newrelic.com/docs/errors-inbox/error-users-impacted/

Task: https://github.com/edx/edx-arch-experiments/issues/140

**Merge checklist:**
- [X] Version bump if needed
- [X] Changelog record added
- [X] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.