### PR TITLE
fix: pin sphinx version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ charset-normalizer==2.1.1
     # via requests
 click==8.1.3
     # via edx-django-utils
-cryptography==38.0.4
+cryptography==39.0.0
     # via pyjwt
 django==3.2.16
     # via

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -10,3 +10,9 @@
 
 # This file contains all common constraints for edx-repos
 -c common_constraints.txt
+
+# Sphinx>5.3.0 requires docutils>=0.18,<0.20 but 
+# sphinx_rtd_theme which needs docutils<0.18 
+# which is causing make upgrade job to fail due to conflicts
+# Constraint can be removed once sphinx_rtd_theme>=1.1.1 is available on PyPI
+sphinx==5.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -60,11 +60,11 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==7.0.0
+coverage[toml]==7.0.3
     # via
     #   -r requirements/test.txt
     #   pytest-cov
-cryptography==38.0.4
+cryptography==39.0.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
@@ -122,7 +122,7 @@ edx-opaque-keys==2.3.0
     # via
     #   -r requirements/base.txt
     #   -r requirements/test.txt
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via
     #   -r requirements/test.txt
     #   pytest
@@ -132,7 +132,7 @@ faker==15.3.4
     # via
     #   -r requirements/test.txt
     #   factory-boy
-filelock==3.8.2
+filelock==3.9.0
     # via
     #   -r requirements/test.txt
     #   tox
@@ -154,7 +154,7 @@ imagesize==1.4.1
     # via
     #   -r requirements/docs.txt
     #   sphinx
-importlib-metadata==5.2.0
+importlib-metadata==6.0.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -172,7 +172,7 @@ jinja2==3.1.2
     #   -r requirements/test.txt
     #   code-annotations
     #   sphinx
-lazy-object-proxy==1.8.0
+lazy-object-proxy==1.9.0
     # via
     #   -r requirements/test.txt
     #   astroid
@@ -202,7 +202,7 @@ pbr==5.11.0
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   stevedore
-platformdirs==2.6.0
+platformdirs==2.6.2
     # via
     #   -r requirements/test.txt
     #   pylint
@@ -233,7 +233,7 @@ pycryptodomex==3.16.0
     #   -r requirements/base.txt
     #   -r requirements/test.txt
     #   pyjwkest
-pygments==2.13.0
+pygments==2.14.0
     # via
     #   -r requirements/docs.txt
     #   sphinx
@@ -331,6 +331,7 @@ snowballstemmer==2.2.0
     #   sphinx
 sphinx==5.3.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/docs.txt
     #   sphinx-rtd-theme
 sphinx-rtd-theme==1.1.1

--- a/requirements/docs.in
+++ b/requirements/docs.in
@@ -2,6 +2,7 @@
 
 # Make sure we don't generate requirements that conflict
 # with test.txt, otherwise dev.txt will fail to generate.
+-c constraints.txt
 -c test.txt
 
 Sphinx>=1.3.6

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -26,7 +26,7 @@ idna==3.4
     #   requests
 imagesize==1.4.1
     # via sphinx
-importlib-metadata==5.2.0
+importlib-metadata==6.0.0
     # via sphinx
 jinja2==3.1.2
     # via
@@ -40,7 +40,7 @@ packaging==22.0
     # via
     #   -c requirements/test.txt
     #   sphinx
-pygments==2.13.0
+pygments==2.14.0
     # via sphinx
 pytz==2022.7
     # via
@@ -54,6 +54,7 @@ snowballstemmer==2.2.0
     # via sphinx
 sphinx==5.3.0
     # via
+    #   -c requirements/constraints.txt
     #   -r requirements/docs.in
     #   sphinx-rtd-theme
 sphinx-rtd-theme==1.1.1

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -4,13 +4,11 @@
 #
 #    make upgrade
 #
-wheel==0.38.4
-    # via -r requirements/pip.in
-
-# The following packages are considered to be unsafe in a requirements file:
 pip==22.3.1
     # via -r requirements/pip.in
 setuptools==59.8.0
     # via
     #   -c requirements/common_constraints.txt
     #   -r requirements/pip.in
+wheel==0.38.4
+    # via -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -38,11 +38,11 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==7.0.0
+coverage[toml]==7.0.3
     # via
     #   -r requirements/test.in
     #   pytest-cov
-cryptography==38.0.4
+cryptography==39.0.0
     # via
     #   -r requirements/base.txt
     #   pyjwt
@@ -78,13 +78,13 @@ edx-lint==5.3.0
     # via -r requirements/test.in
 edx-opaque-keys==2.3.0
     # via -r requirements/base.txt
-exceptiongroup==1.0.4
+exceptiongroup==1.1.0
     # via pytest
 factory-boy==2.12.0
     # via -r requirements/test.in
 faker==15.3.4
     # via factory-boy
-filelock==3.8.2
+filelock==3.9.0
     # via
     #   tox
     #   virtualenv
@@ -106,7 +106,7 @@ isort==5.11.4
     #   pylint
 jinja2==3.1.2
     # via code-annotations
-lazy-object-proxy==1.8.0
+lazy-object-proxy==1.9.0
     # via astroid
 markupsafe==2.1.1
     # via jinja2
@@ -124,7 +124,7 @@ pbr==5.11.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-platformdirs==2.6.0
+platformdirs==2.6.2
     # via
     #   pylint
     #   virtualenv


### PR DESCRIPTION
### Description
- `Sphinx>5.3.0` requires `docutils>=0.18,<0.20` but `sphinx_rtd_theme` which needs `docutils<0.18` is causing make upgrade job to fail due to conflicts.
- Pinned the `Sphinx` version unless sphinx_rtd_theme>=1.1.1 is available on PyPI