### PR TITLE
chore: add additional logging to JWT auth middleware authenticate_credentials

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,14 @@ Change Log
 Unreleased
 ----------
 
+[8.4.1] - 2022-12-18
+--------------------
+
+Added
+~~~~~
+
+* Additional logging in `authenticate_credentials` within the JWT authentication middleware for debugging purposes.
+
 [8.4.0] - 2022-12-16
 --------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.4.0'  # pragma: no cover
+__version__ = '8.4.1'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -98,8 +98,7 @@ class JwtAuthentication(JSONWebTokenAuthentication):
         if username is None:
             raise exceptions.AuthenticationFailed('JWT must include a preferred_username or username claim!')
         try:
-            user, created = get_user_model().objects.get_or_create(username=username)
-            logger.info(f"User {user.id} found for username {username} (created?: {created}")
+            user, __ = get_user_model().objects.get_or_create(username=username)
             attributes_updated = False
             attribute_map = self.get_jwt_claim_attribute_map()
             attributes_to_merge = self.get_jwt_claim_mergeable_attributes()

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -98,7 +98,8 @@ class JwtAuthentication(JSONWebTokenAuthentication):
         if username is None:
             raise exceptions.AuthenticationFailed('JWT must include a preferred_username or username claim!')
         try:
-            user, __ = get_user_model().objects.get_or_create(username=username)
+            user, created = get_user_model().objects.get_or_create(username=username)
+            logger.info(f"User {user.id} found for username {username} (created?: {created}")
             attributes_updated = False
             attribute_map = self.get_jwt_claim_attribute_map()
             attributes_to_merge = self.get_jwt_claim_mergeable_attributes()
@@ -148,7 +149,7 @@ class JwtAuthentication(JSONWebTokenAuthentication):
             if attributes_updated:
                 user.save()
         except Exception as authentication_error:
-            msg = 'User retrieval failed.'
+            msg = f'[edx-drf-extensions] User retrieval failed for username {username}.'
             logger.exception(msg)
             raise exceptions.AuthenticationFailed(msg) from authentication_error
 

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
@@ -167,7 +167,7 @@ class JwtAuthenticationTests(TestCase):
                     JwtAuthentication().authenticate_credentials,
                     {'username': 'test', 'email': 'test@example.com'}
                 )
-                logger.assert_called_with('User retrieval failed.')
+                logger.assert_called_with('[edx-drf-extensions] User retrieval failed for username test.')
 
     def test_authenticate_credentials_no_usernames(self):
         """ Verify an AuthenticationFailed exception is raised if the payload contains no username claim. """


### PR DESCRIPTION
**Description:**

The Enterprise Titans squad is investigating an issue with license-manager where it is intermittently throwing a 401 with a `AuthenticatedFailed('User retrieval failed.')` message that has proved difficult to debug thus far.

The impact is that users are intermittently unable to retrieve their subscription plans/licenses/etc., leading to a degraded and poor experience. 

Something within the JWT authentication's middleware is throwing an exception in `authenticate_credentials`, seemingly related to opening a database connection based on Splunk logs.

We are hoping to add additional logs should they be helpful for further debugging.

**JIRA:**

TBD

**Additional Details**

* **Dependencies:**: List dependencies on other outstanding PRs, issues, etc.
* **Merge deadline:** List merge deadline (if any)
* **Testing instructions:** Provide non-trivial testing instructions
* **Author concerns:** List any concerns about this PR

**Reviewers:**
- [x] tag reviewer

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bump if needed
- [x] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
