### PR TITLE
fix: bump to 8.5.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,13 +12,13 @@ Change Log
 Unreleased
 ----------
 
-[8.5.1] - 2023-04-11
+[8.5.3] - 2023-04-11
 --------------------
 
 Fixed
 ~~~~~
 
-* (Hopefully) fixed the ability to publish edx-drf-extensions, by adding a ``long_description`` to setup.py.
+* (Hopefully) fixed the ability to publish edx-drf-extensions, by adding a ``long_description`` to setup.py. There was no real 8.5.1 or 8.5.2.
 
 [8.5.0] - 2023-04-05
 --------------------

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.5.1'  # pragma: no cover
+__version__ = '8.5.3'  # pragma: no cover


### PR DESCRIPTION
**Description:**

Tags for 8.5.1 and 8.5.2 failed earlier, so
this uses the fresh version of 8.5.3 to test
the fixed packaging.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bump if needed
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
