### PR TITLE
feat: add edx_drf_extensions_version custom attribute

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,14 @@ Change Log
 Unreleased
 ----------
 
+[8.7.0] - 2023-04-14
+--------------------
+
+Added
+~~~~~
+
+* Add ``edx_drf_extensions_version`` to help with rollout of changes in this library across services.
+
 Removed
 ~~~~~~~
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.6.0'  # pragma: no cover
+__version__ = '8.7.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/middleware.py
+++ b/edx_rest_framework_extensions/middleware.py
@@ -7,6 +7,7 @@ from django.utils.deprecation import MiddlewareMixin
 from edx_django_utils import monitoring
 from edx_django_utils.cache import DEFAULT_REQUEST_CACHE
 
+import edx_rest_framework_extensions
 from edx_rest_framework_extensions.auth.jwt.constants import USE_JWT_COOKIE_HEADER
 from edx_rest_framework_extensions.auth.jwt.cookies import jwt_cookie_name
 
@@ -72,6 +73,13 @@ class RequestCustomAttributesMiddleware(MiddlewareMixin):
         """
         Sets all the request custom attributes
         """
+        # .. custom_attribute_name: edx_drf_extensions_version
+        # .. custom_attribute_description: The version of the edx-drf-extensions library installed, which may be
+        #   useful when trying to rollout important changes to all services. Note that RequestCustomAttributesMiddleware
+        #   must be installed for this to work. Also, versions before 8.7.0 will not include this attribute, but
+        #   should have ``request_auth_type_guess``.
+        monitoring.set_custom_attribute('edx_drf_extensions_version', edx_rest_framework_extensions.__version__)
+
         self._set_request_auth_type_guess_attribute(request)
         self._set_request_user_agent_attributes(request)
         self._set_request_referer_attribute(request)

--- a/edx_rest_framework_extensions/tests/test_middleware.py
+++ b/edx_rest_framework_extensions/tests/test_middleware.py
@@ -36,7 +36,7 @@ class TestRequestCustomAttributesMiddleware(TestCase):
             x.args[1] for x in mock_set_custom_attribute.call_args_list if x.args[0] == 'edx_drf_extensions_version'
         ]
         assert len(version_list) == 1
-        assert re.search('\d+\.\d+\.\d+', version_list[0])
+        assert re.search(r'\d+\.\d+\.\d+', version_list[0])
 
     @patch('edx_django_utils.monitoring.set_custom_attribute')
     def test_request_auth_type_guess_anonymous_attribute(self, mock_set_custom_attribute):

--- a/edx_rest_framework_extensions/tests/test_middleware.py
+++ b/edx_rest_framework_extensions/tests/test_middleware.py
@@ -43,13 +43,13 @@ class TestRequestCustomAttributesMiddleware(TestCase):
         self.request.user = AnonymousUser()
 
         self.middleware.process_response(self.request, None)
-        mock_set_custom_attribute.assert_called_once_with('request_auth_type_guess', 'unauthenticated')
+        mock_set_custom_attribute.assert_called_with('request_auth_type_guess', 'unauthenticated')
 
     @patch('edx_django_utils.monitoring.set_custom_attribute')
     def test_request_no_headers(self, mock_set_custom_attribute):
         self.request.user = None
         self.middleware.process_response(self.request, None)
-        mock_set_custom_attribute.assert_called_once_with('request_auth_type_guess', 'no-user')
+        mock_set_custom_attribute.assert_called_with('request_auth_type_guess', 'no-user')
 
     @patch('edx_django_utils.monitoring.set_custom_attribute')
     def test_request_blank_headers(self, mock_set_custom_attribute):
@@ -58,7 +58,7 @@ class TestRequestCustomAttributesMiddleware(TestCase):
         self.request.META['HTTP_AUTHORIZATION'] = ''
 
         self.middleware.process_response(self.request, None)
-        mock_set_custom_attribute.assert_called_once_with('request_auth_type_guess', 'no-user')
+        mock_set_custom_attribute.assert_called_with('request_auth_type_guess', 'no-user')
 
     @patch('edx_django_utils.monitoring.set_custom_attribute')
     def test_request_referer_attribute(self, mock_set_custom_attribute):
@@ -237,4 +237,4 @@ class TestRequestMetricsMiddleware(TestCase):
         self.request.user = AnonymousUser()
 
         self.middleware.process_response(self.request, None)
-        mock_set_custom_attribute.assert_called_once_with('request_auth_type_guess', 'unauthenticated')
+        mock_set_custom_attribute.assert_called_with('request_auth_type_guess', 'unauthenticated')


### PR DESCRIPTION
**Description:**

Add edx_drf_extensions_version custom attribute to help monitor rollout of upgrades to this library.

Requires use of RequestCustomAttributesMiddleware. Versions before 8.7.0 will not include this attribute, but should include `request_auth_type_guess`.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bump if needed
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
