### PR TITLE
chore: Fix RemovedInDjango40Warning for middleware get_response

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,13 @@ Change Log
 Unreleased
 ----------
 
+[8.9.1] - 2023-08-22
+--------------------
+
+Fixed
+~~~~~
+* Fixed Django 40 middleware deprecation warning
+
 [8.9.0] - 2023-08-14
 --------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.9.0'  # pragma: no cover
+__version__ = '8.9.1'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -192,11 +192,7 @@ class JwtAuthentication(JSONWebTokenAuthentication):
         Copied from SessionAuthentication.
         See https://github.com/encode/django-rest-framework/blob/3f19e66d9f2569895af6e91455e5cf53b8ce5640/rest_framework/authentication.py#L131-L141  # noqa E501 line too long
         """
-
-        def dummy_get_response(request):  # pylint: disable=unused-argument
-            return None
-
-        check = CSRFCheck(dummy_get_response)  # pylint: disable=no-value-for-parameter
+        check = CSRFCheck(get_response=lambda request: None)
         # populates request.META['CSRF_COOKIE'], which is used in process_view()
         check.process_request(request)
         reason = check.process_view(request, None, (), {})

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -193,7 +193,7 @@ class JwtAuthentication(JSONWebTokenAuthentication):
         See https://github.com/encode/django-rest-framework/blob/3f19e66d9f2569895af6e91455e5cf53b8ce5640/rest_framework/authentication.py#L131-L141  # noqa E501 line too long
         """
 
-        def dummy_get_response(request):  # pragma: no cover
+        def dummy_get_response(request):  # pylint: disable=unused-argument
             return None
 
         check = CSRFCheck(dummy_get_response)  # pylint: disable=no-value-for-parameter

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -192,7 +192,11 @@ class JwtAuthentication(JSONWebTokenAuthentication):
         Copied from SessionAuthentication.
         See https://github.com/encode/django-rest-framework/blob/3f19e66d9f2569895af6e91455e5cf53b8ce5640/rest_framework/authentication.py#L131-L141  # noqa E501 line too long
         """
-        check = CSRFCheck()  # pylint: disable=no-value-for-parameter
+
+        def dummy_get_response(request):  # pragma: no cover
+            return None
+
+        check = CSRFCheck(dummy_get_response)  # pylint: disable=no-value-for-parameter
         # populates request.META['CSRF_COOKIE'], which is used in process_view()
         check.process_request(request)
         reason = check.process_view(request, None, (), {})


### PR DESCRIPTION
Fixing django40 warning.