### PR TITLE
fix: exceptional case with JwtAuthentication

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,11 @@ Fixed
 ~~~~~
 * Fixes exceptional case where JwtAuthentication should not CSRF protect a request that has both a JWT token in the authorization header and a JWT cookie, since the cookie should be ignored.
 
+Changed
+~~~~~~~
+* Updated one of the values of the custom attribute jwt_auth_result from 'skipped' to 'n/a'.
+
+
 [8.9.1] - 2023-08-22
 --------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,13 @@ Change Log
 Unreleased
 ----------
 
+[8.9.2] - 2023-08-31
+--------------------
+
+Fixed
+~~~~~
+* Fixes exceptional case where JwtAuthentication should not CSRF protect a request that has both a JWT token in the authorization header and a JWT cookie, since the cookie should be ignored.
+
 [8.9.1] - 2023-08-22
 --------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.9.1'  # pragma: no cover
+__version__ = '8.9.2'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -69,7 +69,7 @@ class JwtAuthentication(JSONWebTokenAuthentication):
         # .. custom_attribute_name: jwt_auth_result
         # .. custom_attribute_description: The result of the JWT authenticate process,
         #      which can having the following values:
-        #        'skipped': When JWT Authentication doesn't apply.
+        #        'n/a': When JWT Authentication doesn't apply.
         #        'success-auth-header': Successfully authenticated using the Authorization header.
         #        'success-cookie': Successfully authenticated using a JWT cookie.
         #        'forgiven-failure': Returns None instead of failing for JWT cookies. This handles
@@ -87,7 +87,7 @@ class JwtAuthentication(JSONWebTokenAuthentication):
 
             # Unauthenticated, CSRF validation not required
             if not user_and_auth:
-                set_custom_attribute('jwt_auth_result', 'skipped')
+                set_custom_attribute('jwt_auth_result', 'n/a')
                 return user_and_auth
 
             # Not using JWT cookie, CSRF validation not required

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
@@ -285,7 +285,7 @@ class JwtAuthenticationTests(TestCase):
         auth_header = '{token_name} {token}'.format(token_name='Bearer', token='abc123')
         request = RequestFactory().get('/', HTTP_AUTHORIZATION=auth_header)
         self.assertIsNone(JwtAuthentication().authenticate(request))
-        mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'skipped')
+        mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'n/a')
 
     def _get_test_jwt_token(self):
         """ Returns a user and jwt token """

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
@@ -244,7 +244,7 @@ class JwtAuthenticationTests(TestCase):
     @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
     def test_authenticate_with_correct_jwt_authorization(self, mock_set_custom_attribute):
         """
-        With JWT header it continues and validates the credentials and throws error.
+        With JWT header it continues and validates the credentials.
 
         Note: CSRF protection should be skipped for this case, with no PermissionDenied.
         """
@@ -265,6 +265,19 @@ class JwtAuthenticationTests(TestCase):
         with self.assertRaises(AuthenticationFailed):
             JwtAuthentication().authenticate(request)
         mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'failed-auth-header')
+
+    @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
+    def test_authenticate_with_correct_jwt_authorization_and_bad_cookie(self, mock_set_custom_attribute):
+        """
+        With JWT header it continues and validates the credentials and ignores the invalid cookie.
+
+        Note: CSRF protection should be skipped for this case, with no PermissionDenied.
+        """
+        jwt_token = self._get_test_jwt_token()
+        request = RequestFactory().get('/', HTTP_AUTHORIZATION=f"JWT {jwt_token}")
+        request.COOKIES[jwt_cookie_name()] = 'foo'
+        assert JwtAuthentication().authenticate(request)
+        mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'success-auth-header')
 
     @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
     def test_authenticate_with_bearer_token(self, mock_set_custom_attribute):


### PR DESCRIPTION
**Description:**

Fixes exceptional case where JwtAuthentication should not CSRF protect a request that has both a JWT token in the authorization header and a JWT cookie, since the cookie should be ignored.

Note: I had minor concerns that Mobile could have issues here, and I just didn't want to have that concern, so I took care of the exceptional case.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bump if needed
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.