### PR TITLE
fix: Add more monitoring to the JWT Auth Class.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ Change Log
 Unreleased
 ----------
 
+[8.9.3] - 2023-09-13
+--------------------
+
+Fixed
+~~~~~
+
+* Added more useful exception logging when JWT auth fails.  The exception we
+  get for that did not have enough detail about how the auth check failed so we
+  dig deeper to an exception that is more useful and log that.
+
 [8.9.2] - 2023-08-31
 --------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.9.2'  # pragma: no cover
+__version__ = '8.9.3'  # pragma: no cover


### PR DESCRIPTION
The default exception that comes from the JSONWebTokenAuthentication
does not have enough information about why the JWT auth failed in the
exception that it propagates.  However, we can get this information by
looking at the PyJWT exception that was thrown so we added some tooling
to get that lower level exception if it exists.

### ToDo

- [ ] Bump the version
- [ ] Update changelog
