### PR TITLE
feat: handle jwt cookie vs session user mismatch 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,16 @@ Change Log
 Unreleased
 ----------
 
+[8.11.0] - 2023-10-04
+---------------------
+
+Added
+~~~~~
+* Added toggle EDX_DRF_EXTENSIONS[ENABLE_JWT_VS_SESSION_USER_CHECK] to enable the following:
+
+    * New custom attributes is_jwt_vs_session_user_check_enabled, jwt_auth_session_user_id, jwt_auth_and_session_user_mismatch, and invalid_jwt_cookie_user_id for monitoring and debugging.
+    * When forgiving JWT cookies are also enabled, user mismatches will now result in a failure, rather than a forgiving JWT.
+
 [8.10.0] - 2023-09-19
 ---------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.10.0'  # pragma: no cover
+__version__ = '8.11.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -250,7 +250,8 @@ class JwtAuthentication(JSONWebTokenAuthentication):
         # .. custom_attribute_description: The user_id pulled from the failed
         #     JWT cookie. If the user_id claim is not found in the JWT, the attribute
         #     value will be 'not-found'. If the failed JWT simply can't be decoded,
-        #     the attribute value will be 'decode-error'.
+        #     the attribute value will be 'decode-error'. Note: for successful JWTs,
+        #     the user id will already be available in `enduser.id` or `request_user_id`.
         set_custom_attribute('failed_jwt_cookie_user_id', jwt_user_id_attribute_value)
 
         return self._is_jwt_cookie_and_session_user_mismatch(request, jwt_user_id)

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -9,8 +9,14 @@ from jwt import exceptions as jwt_exceptions
 from rest_framework import exceptions
 from rest_framework_jwt.authentication import JSONWebTokenAuthentication
 
-from edx_rest_framework_extensions.auth.jwt.decoder import configured_jwt_decode_handler
-from edx_rest_framework_extensions.config import ENABLE_FORGIVING_JWT_COOKIES
+from edx_rest_framework_extensions.auth.jwt.decoder import (
+    configured_jwt_decode_handler,
+    unsafe_jwt_decode_handler,
+)
+from edx_rest_framework_extensions.config import (
+    ENABLE_FORGIVING_JWT_COOKIES,
+    ENABLE_JWT_VS_SESSION_USER_CHECK,
+)
 from edx_rest_framework_extensions.settings import get_setting
 
 
@@ -100,6 +106,8 @@ class JwtAuthentication(JSONWebTokenAuthentication):
 
             # CSRF passed validation with authenticated user
             set_custom_attribute('jwt_auth_result', 'success-cookie')
+            # adds additional monitoring for mismatches
+            self._is_jwt_cookie_and_session_user_mismatched(request, jwt_user=user_and_auth[0])
             return user_and_auth
 
         except Exception as exception:
@@ -112,14 +120,19 @@ class JwtAuthentication(JSONWebTokenAuthentication):
             exception_to_report = _deepest_jwt_exception(exception)
             set_custom_attribute('jwt_auth_failed', 'Exception:{}'.format(repr(exception_to_report)))
 
-            is_jwt_failure_forgiven = is_forgiving_jwt_cookies_enabled and is_authenticating_with_jwt_cookie
-            if is_jwt_failure_forgiven:
-                set_custom_attribute('jwt_auth_result', 'forgiven-failure')
-                return None
             if is_authenticating_with_jwt_cookie:
+                # This check also adds monitoring details for all failed JWT cookies
+                is_user_mismatch = self._is_jwt_cookie_and_session_user_mismatched(request)
+                if is_forgiving_jwt_cookies_enabled:
+                    if is_user_mismatch:
+                        set_custom_attribute('jwt_auth_result', 'user-mismatch-failure')
+                        raise
+                    set_custom_attribute('jwt_auth_result', 'forgiven-failure')
+                    return None
                 set_custom_attribute('jwt_auth_result', 'failed-cookie')
-            else:
-                set_custom_attribute('jwt_auth_result', 'failed-auth-header')
+                raise
+
+            set_custom_attribute('jwt_auth_result', 'failed-auth-header')
             raise
 
     def authenticate_credentials(self, payload):
@@ -215,6 +228,78 @@ class JwtAuthentication(JSONWebTokenAuthentication):
             return cookie_token and (request_token == cookie_token)
         except Exception:  # pylint: disable=broad-exception-caught
             return False
+
+    def _is_jwt_cookie_and_session_user_mismatched(self, request, jwt_user=None):
+        """
+        Returns True if JWT cookie and session user do not match, False otherwise.
+
+        Arguments:
+            request: The request.
+            jwt_user (User): The valid JWT user. If not user is supplied, it is assumed that
+                the cookie was invalid, and we attempt to get the user_id from the invalid
+                token.
+
+        Other notes:
+        - If ENABLE_JWT_VS_SESSION_USER_CHECK is toggled off, always return False.
+        - Also adds monitoring details for mismatches.
+        - Should only be called for JWT cookies.
+        """
+        is_jwt_vs_session_user_check_enabled = get_setting(ENABLE_JWT_VS_SESSION_USER_CHECK)
+        # .. custom_attribute_name: is_jwt_vs_session_user_check_enabled
+        # .. custom_attribute_description: This is temporary custom attribute to show
+        #      whether ENABLE_JWT_VS_SESSION_USER_CHECK is toggled on or off.
+        set_custom_attribute('is_jwt_vs_session_user_check_enabled', is_jwt_vs_session_user_check_enabled)
+        if not is_jwt_vs_session_user_check_enabled:
+            return False
+
+        has_request_user = (
+            hasattr(request, '_request') and hasattr(request._request, 'user')  # pylint: disable=protected-access
+        )
+        if not has_request_user:  # pragma: no cover
+            # .. custom_attribute_name: jwt_auth_request_user_not_found
+            # .. custom_attribute_description: This custom attribute will show that we
+            #      were unable to find the session user. This should not occur outside
+            #      of tests, because there should still be an unauthenticated user, but
+            #      this attribute could be used to check for the unexpected.
+            set_custom_attribute('jwt_auth_request_user_not_found', True)
+            return False
+
+        wsgi_request_user = request._request.user  # pylint: disable=protected-access
+        if wsgi_request_user and wsgi_request_user.is_authenticated:
+            session_user_id = wsgi_request_user.id
+        else:
+            session_user_id = None
+
+        if jwt_user:
+            jwt_user_id = jwt_user.id
+        else:
+            cookie_token = JSONWebTokenAuthentication.get_token_from_cookies(request.COOKIES)
+            invalid_decoded_jwt = unsafe_jwt_decode_handler(cookie_token)
+            jwt_user_id = invalid_decoded_jwt['user_id']
+            # .. custom_attribute_name: invalid_jwt_cookie_user_id
+            # .. custom_attribute_description: The user_id pulled from the invalid/failed
+            #     JWT cookie.
+            set_custom_attribute('invalid_jwt_cookie_user_id', jwt_user_id)
+
+        if not session_user_id or session_user_id == jwt_user_id:
+            return False
+
+        # .. custom_attribute_name: jwt_auth_session_user_id
+        # .. custom_attribute_description: Session authentication may have completed
+        #       in middleware before even getting to DRF. Although this authentication
+        #       won't stick, because it will be replaced by DRF authentication, we
+        #       record it, because it sometimes does not match the JWT cookie user.
+        #       The name of this attribute is simply to clarify that this was found
+        #       during JWT authentication.
+        set_custom_attribute('jwt_auth_session_user_id', session_user_id)
+
+        # .. custom_attribute_name: jwt_auth_and_session_user_mismatch
+        # .. custom_attribute_description: True if session authentication user id and
+        #       the JWT cookie user id may not match. When they match, this attribute
+        #       won't be included. See jwt_auth_session_user_id for additional details.
+        set_custom_attribute('jwt_auth_and_session_user_mismatch', True)
+
+        return True
 
 
 def is_jwt_authenticated(request):

--- a/edx_rest_framework_extensions/auth/jwt/decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/decoder.py
@@ -74,6 +74,23 @@ def jwt_decode_handler(token, decode_symmetric_token=True):
     return _set_token_defaults(decoded_token)
 
 
+def unsafe_jwt_decode_handler(token):
+    """
+    Decodes a JSON Web Token (JWT) with NO verification.
+
+    Args:
+        token (str): JWT to be decoded.
+
+    Returns:
+        dict: Decoded JWT payload
+
+    Raises:
+        InvalidTokenError: Decoding fails.
+    """
+    decoded_token = _unsafe_decode_token_with_no_verification(token)
+    return _set_token_defaults(decoded_token)
+
+
 def configured_jwt_decode_handler(token):
     """
     Calls the ``jwt_decode_handler`` configured in the ``JWT_DECODE_HANDLER`` setting.
@@ -358,6 +375,20 @@ def _decode_and_verify_token(token, jwt_issuer):
         logger.info('Token decode failed due to mismatched issuer [%s]', token_issuer)
         raise jwt.InvalidTokenError('%s is not a valid issuer.' % token_issuer)
 
+    return decoded_token
+
+
+def _unsafe_decode_token_with_no_verification(token):
+    """
+    Returns a decoded JWT token with no verification.
+    """
+    options = {
+        'verify_exp': False,
+        'verify_aud': False,
+        'verify_iss': False,
+        'verify_signature': False,
+    }
+    decoded_token = jwt.decode(token, options=options)
     return decoded_token
 
 

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_decoder.py
@@ -13,6 +13,7 @@ from edx_rest_framework_extensions.auth.jwt.decoder import (
     decode_jwt_scopes,
     get_asymmetric_only_jwt_decode_handler,
     jwt_decode_handler,
+    unsafe_jwt_decode_handler,
 )
 from edx_rest_framework_extensions.auth.jwt.tests.utils import (
     generate_asymmetric_jwt_token,
@@ -233,6 +234,20 @@ class JWTDecodeHandlerTests(TestCase):
             mock.call('jwt_auth_issuer', 'test-issuer-1'),
             mock.call('jwt_auth_issuer_verification', 'matches-first-issuer'),
         ]
+
+    def test_unsafe_success_with_invalid_token(self):
+        """
+        Verifies unsafe decode is successful, even with invalid claims and signature
+        """
+        self.payload['iss'] = 'invalid-iss'
+        self.payload['exp'] = 'invalid-exp'
+        self.payload['aud'] = 'invalid-aud'
+        invalid_signing_key = 'invalid-secret-key'
+
+        # Generate a token using the invalid signing key
+        token = generate_jwt_token(self.payload, invalid_signing_key)
+        decoded_token = unsafe_jwt_decode_handler(token)
+        assert decoded_token['username'] is not None
 
 
 def _jwt_decode_handler_with_defaults(token):  # pylint: disable=unused-argument

--- a/edx_rest_framework_extensions/auth/jwt/tests/utils.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/utils.py
@@ -70,6 +70,7 @@ def generate_unversioned_payload(user):
         'iss': jwt_issuer_data['ISSUER'],
         'aud': jwt_issuer_data['AUDIENCE'],
         'username': user.username,
+        'user_id': user.id,  # this should be conditionally added based on the scope
         'email': user.email,
         'iat': now,
         'exp': now + ttl,

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -22,3 +22,17 @@ ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE = 'ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE
 # .. toggle_target_removal_date: 2023-10-01
 # .. toggle_tickets: https://github.com/openedx/edx-drf-extensions/issues/371
 ENABLE_FORGIVING_JWT_COOKIES = 'ENABLE_FORGIVING_JWT_COOKIES'
+
+# .. toggle_name: EDX_DRF_EXTENSIONS[ENABLE_JWT_VS_SESSION_USER_CHECK]
+# .. toggle_implementation: DjangoSetting
+# .. toggle_default: False
+# .. toggle_description: If True, checks for mismatches of JWT cookie user and session user. If forgiving
+#       JWT cookies is also enabled, mismatches will result in an error, rather than being forgiving. Also
+#       adds monitoring of session user vs JWT cookie user.
+# .. toggle_warning: Since edx-platform has user caching, this toggle is a safety valve in case it
+#       starts causing memory issues, as has happened in the past. See ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE.
+# .. toggle_use_cases: temporary
+# .. toggle_creation_date: 2023-10-04
+# .. toggle_target_removal_date: 2023-12-01
+# .. toggle_tickets: https://github.com/openedx/edx-drf-extensions/issues/371
+ENABLE_JWT_VS_SESSION_USER_CHECK = 'ENABLE_JWT_VS_SESSION_USER_CHECK'

--- a/edx_rest_framework_extensions/settings.py
+++ b/edx_rest_framework_extensions/settings.py
@@ -17,6 +17,7 @@ from rest_framework_jwt.settings import api_settings
 
 from edx_rest_framework_extensions.config import (
     ENABLE_FORGIVING_JWT_COOKIES,
+    ENABLE_JWT_VS_SESSION_USER_CHECK,
     ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE,
 )
 
@@ -35,6 +36,7 @@ DEFAULT_SETTINGS = {
     'JWT_PAYLOAD_MERGEABLE_USER_ATTRIBUTES': (),
     ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE: False,
     ENABLE_FORGIVING_JWT_COOKIES: False,
+    ENABLE_JWT_VS_SESSION_USER_CHECK: False,
 }
 
 

--- a/test_settings.py
+++ b/test_settings.py
@@ -13,6 +13,7 @@ INSTALLED_APPS = (
     'csrf.apps.CsrfAppConfig',
     'django.contrib.auth',
     'django.contrib.contenttypes',
+    'django.contrib.sessions',
     'edx_rest_framework_extensions',
     'rest_framework_jwt',
     'waffle',


### PR DESCRIPTION
**Description:**

Adds toggle
EDX_DRF_EXTENSIONS[ENABLE_JWT_VS_SESSION_USER_MONITORING]
to enable the following features:

- New custom attributes is_jwt_vs_session_user_check_enabled,
 jwt_auth_session_user_id, jwt_auth_and_session_user_mismatch,
 and invalid_jwt_cookie_user_id for monitoring and debugging.
- When forgiving JWT cookies are also enabled, user mismatches
 will now result in a failure, rather than a forgiving JWT.

This implements https://github.com/openedx/edx-drf-extensions/issues/381#issuecomment-1729755383.

**Merge checklist:**
- [x] All reviewers approved
- [ ] CI build is green
- [ ] Version bump if needed
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
