### PR TITLE
docs: update CHANGELOG.rst for 8.11.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,10 @@ Added
     * New custom attributes is_jwt_vs_session_user_check_enabled, jwt_auth_session_user_id, jwt_auth_and_session_user_mismatch, and invalid_jwt_cookie_user_id for monitoring and debugging.
     * When forgiving JWT cookies are also enabled, user mismatches will now result in a failure, rather than a forgiving JWT.
 
+Changed
+~~~~~~~
+* BREAKING CHANGE: For tests only, the test utility method generate_unversioned_payload now requires that the user argument contains an id attribute. In the case of a Mock user, you must set user.id.
+
 [8.10.0] - 2023-09-19
 ---------------------
 


### PR DESCRIPTION
**Description:**

A small backward incompatible change was found in the updated test utility method generate_unversioned_payload. The user argument now requires an id attribute. The changelog has been updated to reflect this.

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bump if needed
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed