### PR TITLE
fix: update jwt vs session user monitoring

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,25 @@ Change Log
 Unreleased
 ----------
 
+[8.13.0] - 2023-10-30
+---------------------
+
+Fixed
+~~~~~
+* Bug fix for when both ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE and the JWT cookie user vs session user check behind ENABLE_FORGIVING_JWT_COOKIES were enabled at the same time.
+
+Added
+~~~~~
+* Added custom attributes set_user_from_jwt_status and skip_jwt_vs_session_check.
+
+Updated
+~~~~~~~
+* ADR for removing HTTP_USE_JWT_COOKIE, which explains forgiven JWT cookies, was updated to explain the cases where the JWT cookie user and session user do not match.
+
+Removed
+~~~~~~~
+* Toggle EDX_DRF_EXTENSIONS[ENABLE_JWT_VS_SESSION_USER_CHECK] has been removed. This check is now a default part of the ENABLE_FORGIVING_JWT_COOKIES functionality. ENABLE_JWT_VS_SESSION_USER_CHECK was just a temporary roll-out toggle that was already proven out everywhere ENABLE_FORGIVING_JWT_COOKIES was already enabled.
+
 [8.12.0] - 2023-10-16
 ---------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.12.0'  # pragma: no cover
+__version__ = '8.13.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_middleware.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_middleware.py
@@ -109,7 +109,7 @@ class TestEnsureJWTAuthSettingsMiddleware(TestCase):
         }
         view_classes = {
             "class_view": SomeClassView,
-            "view_set": views['view_set'].cls,
+            "view_set": views['view_set'].cls,  # pylint: disable=no-member
             "function_view": views['function_view'].view_class,
         }
         view = views[view_type]

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -22,17 +22,3 @@ ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE = 'ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE
 # .. toggle_target_removal_date: 2023-10-01
 # .. toggle_tickets: https://github.com/openedx/edx-drf-extensions/issues/371
 ENABLE_FORGIVING_JWT_COOKIES = 'ENABLE_FORGIVING_JWT_COOKIES'
-
-# .. toggle_name: EDX_DRF_EXTENSIONS[ENABLE_JWT_VS_SESSION_USER_CHECK]
-# .. toggle_implementation: DjangoSetting
-# .. toggle_default: False
-# .. toggle_description: If True, checks for mismatches of JWT cookie user and session user. If forgiving
-#       JWT cookies is also enabled, mismatches will result in an error, rather than being forgiving. Also
-#       adds monitoring of session user vs JWT cookie user.
-# .. toggle_warning: Since edx-platform has user caching, this toggle is a safety valve in case it
-#       starts causing memory issues, as has happened in the past. See ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE.
-# .. toggle_use_cases: temporary
-# .. toggle_creation_date: 2023-10-04
-# .. toggle_target_removal_date: 2023-12-01
-# .. toggle_tickets: https://github.com/openedx/edx-drf-extensions/issues/371
-ENABLE_JWT_VS_SESSION_USER_CHECK = 'ENABLE_JWT_VS_SESSION_USER_CHECK'

--- a/edx_rest_framework_extensions/settings.py
+++ b/edx_rest_framework_extensions/settings.py
@@ -17,7 +17,6 @@ from rest_framework_jwt.settings import api_settings
 
 from edx_rest_framework_extensions.config import (
     ENABLE_FORGIVING_JWT_COOKIES,
-    ENABLE_JWT_VS_SESSION_USER_CHECK,
     ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE,
 )
 
@@ -36,7 +35,6 @@ DEFAULT_SETTINGS = {
     'JWT_PAYLOAD_MERGEABLE_USER_ATTRIBUTES': (),
     ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE: False,
     ENABLE_FORGIVING_JWT_COOKIES: False,
-    ENABLE_JWT_VS_SESSION_USER_CHECK: False,
 }
 
 


### PR DESCRIPTION
**Description:**

An issue was found when both ENABLE_JWT_VS_SESSION_USER_CHECK and ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE were enabled at the same time in an ecommerce stage environment for edx.org, that is not reproducible locally. Additionally, the issue killed the requests without providing errors, so potentially caused an infinite loop or some such issue.

The guess is that the code for setting the user behind ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE, and the code to get the user in the new ENABLE_JWT_VS_SESSION_USER_CHECK check, were somehow in conflict. This update attempts to skip the JWT vs Session check in the case that we have set the user based on the JWT, in which case it would be a JWT vs JWT check, which not only is unnecessary, but also may be the cause of the issue.

Adds custom attributes:
- set_user_from_jwt_status
- skip_jwt_vs_session_check

**Issue:**

https://github.com/edx/edx-arch-experiments/issues/429

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bump if needed
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
