### PR TITLE
fix: JwtAuthentication with Django request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,13 @@ Change Log
 Unreleased
 ----------
 
+[8.13.1] - 2023-11-15
+---------------------
+
+Fixed
+~~~~~
+* Fixed bug where JwtAuthentication called with a Django request instead of a DRF request would fail. Also added custom attribute jwt_auth_request_user_not_found to track down these unexpected cases.
+
 [8.13.0] - 2023-10-30
 ---------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.13.0'  # pragma: no cover
+__version__ = '8.13.1'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -330,9 +330,18 @@ class JwtAuthentication(JSONWebTokenAuthentication):
             set_custom_attribute('skip_jwt_vs_session_check', True)
             return False
 
+        wsgi_request = getattr(request, '_request', request)
+        if wsgi_request == request:
+            # .. custom_attribute_name: jwt_auth_with_django_request
+            # .. custom_attribute_description: There exists custom authentication code in the platform that is
+            #      calling JwtAuthentication with a Django request, rather than the expected DRF request. This
+            #      custom attribute could be used to track down those usages and find ways to elimitate custom
+            #      authentication code that lives outside of this library.
+            set_custom_attribute('jwt_auth_with_django_request', True)
+
         # Get the session-based user from the underlying HttpRequest object.
         # This line taken from DRF SessionAuthentication.
-        user = getattr(request._request, 'user', None)  # pylint: disable=protected-access
+        user = getattr(wsgi_request, 'user', None)
         if not user:  # pragma: no cover
             # .. custom_attribute_name: jwt_auth_request_user_not_found
             # .. custom_attribute_description: This custom attribute shows when a


### PR DESCRIPTION
**Description:**

Fixed bug where JwtAuthentication called with a Django request instead of a DRF request would fail. Also added custom attribute jwt_auth_request_user_not_found to track down these unexpected cases.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bump if needed
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
