### PR TITLE
fix!: bug in JWT vs session user id compare

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,9 +19,9 @@ Fixed
 * **BREAKING CHANGE**: Fixes a bug for any service other than the identity service (LMS/CMS), where the session's local service user id would never match the JWT LMS user id when compared.
 
   * The custom attribute jwt_auth_mismatch_session_lms_user_id was renamed to jwt_auth_mismatch_session_lms_user_id to make this more clear.
-  * The setting EDX_DRF_EXTENSIONS[VERIFY_LMS_USER_ID_PROPERTY_NAME] was added to enable choosing the user object property that contains the lms_user_id, if one exists. If this is unset, a service will simply skip this additional protection.
+  * The setting EDX_DRF_EXTENSIONS[VERIFY_LMS_USER_ID_PROPERTY_NAME] was added to enable choosing the user object property that contains the LMS user id, if one exists. If this is set to None (the default), the check will use the lms_user_id property if it is found, and otherwise will skip this additional protection. In case of an unforeseen issue, use 'skip-check' to skip the check, even when there is an lms_user_id property.
   * The custom attribute jwt_auth_get_lms_user_id_status was added to provide observability into the new functionality.
-  * The breaking change only affects services with ENABLE_FORGIVING_JWT_COOKIES enabled. It now requires the new setting VERIFY_LMS_USER_ID_PROPERTY_NAME to be set in order to provide the existing Session vs JWT user id check.
+  * The breaking change only affects services with ENABLE_FORGIVING_JWT_COOKIES enabled. It now requires the new setting VERIFY_LMS_USER_ID_PROPERTY_NAME to be set appropriately in order to provide the existing Session vs JWT user id check. Note that only LMS/CMS will likely need to set this value.
 
 [8.13.1] - 2023-11-15
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,17 @@ Change Log
 Unreleased
 ----------
 
+[9.0.0] - 2023-11-27
+
+Fixed
+~~~~~
+* **BREAKING CHANGE**: Fixes a bug for any service other than the identity service (LMS/CMS), where the session's local service user id would never match the JWT LMS user id when compared.
+
+  * The custom attribute jwt_auth_mismatch_session_lms_user_id was renamed to jwt_auth_mismatch_session_lms_user_id to make this more clear.
+  * The setting EDX_DRF_EXTENSIONS[VERIFY_LMS_USER_ID_PROPERTY_NAME] was added to enable choosing the user object property that contains the lms_user_id, if one exists. If this is unset, a service will simply skip this additional protection.
+  * The custom attribute jwt_auth_get_lms_user_id_status was added to provide observability into the new functionality.
+  * The breaking change only affects services with ENABLE_FORGIVING_JWT_COOKIES enabled. It now requires the new setting VERIFY_LMS_USER_ID_PROPERTY_NAME to be set in order to provide the existing Session vs JWT user id check.
+
 [8.13.1] - 2023-11-15
 ---------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '8.13.1'  # pragma: no cover
+__version__ = '9.0.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -28,9 +28,13 @@ ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE = 'ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE
 ENABLE_FORGIVING_JWT_COOKIES = 'ENABLE_FORGIVING_JWT_COOKIES'
 
 # .. setting_name: EDX_DRF_EXTENSIONS[VERIFY_LMS_USER_ID_PROPERTY_NAME]
-# .. setting_default: None
-# .. setting_description: This setting should be set to the name of the user attribute property containing the LMS
-#      user id. Examples might be `id` or `lms_user_id`. If there is no property, leave the default value of None.
-#      This is used by JWT cookie authentication to verify that the (LMS) user id in the JWT is the same
-#      as the LMS user id for a service's session.
+# .. setting_default: None ('lms_user_id' if found)
+# .. setting_description: This setting should be set to the name of the user object property containing the LMS
+#      user id, if one exists. Examples might be 'id' or 'lms_user_id'. To enhance security and provide ease of use
+#      for this setting, if None is supplied, the property 'lms_user_id' will be used if found. In case of unforeseen
+#      issues using lms_user_id, the check can be fully disabled using 'skip-check' as the property name. The default
+#      was not set to 'lms_user_id' directly to avoid misconfiguration logging for services without an lms_user_id
+#      property. The property named by this setting will be used by JWT cookie authentication to verify that the (LMS)
+#      user id in the JWT is the same as the LMS user id for a service's session. This will cause failures in the case
+#      of forgiving cookies, and will simply be used for additional monitoring for successful cookie authentication.
 VERIFY_LMS_USER_ID_PROPERTY_NAME = 'VERIFY_LMS_USER_ID_PROPERTY_NAME'

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -5,11 +5,15 @@ Application configuration constants and code.
 # .. toggle_name: EDX_DRF_EXTENSIONS[ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE]
 # .. toggle_implementation: DjangoSetting
 # .. toggle_default: False
-# .. toggle_description: Toggle for setting request.user with jwt cookie authentication
+# .. toggle_description: Toggle for setting request.user with jwt cookie authentication. This makes the JWT cookie
+#      user available to middleware while processing the request, if the session user wasn't already available. This
+#      requires JwtAuthCookieMiddleware to work. It is recommended to set VERIFY_LMS_USER_ID_PROPERTY_NAME if possible
+#      when using this feature.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-10-15
-# .. toggle_target_removal_date: 2019-12-31
-# .. toggle_warning: This feature fixed ecommerce, but broke edx-platform. The toggle enables us to fix over time.
+# .. toggle_target_removal_date: 2024-12-31
+# .. toggle_warning: This feature caused a memory leak in edx-platform. This toggle is temporary only if we can make it
+#      work in all services, or find a replacement. Consider making this a permanent toggle instead.
 # .. toggle_tickets: ARCH-1210, ARCH-1199, ARCH-1197
 ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE = 'ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE'
 
@@ -22,3 +26,11 @@ ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE = 'ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE
 # .. toggle_target_removal_date: 2023-10-01
 # .. toggle_tickets: https://github.com/openedx/edx-drf-extensions/issues/371
 ENABLE_FORGIVING_JWT_COOKIES = 'ENABLE_FORGIVING_JWT_COOKIES'
+
+# .. setting_name: EDX_DRF_EXTENSIONS[VERIFY_LMS_USER_ID_PROPERTY_NAME]
+# .. setting_default: None
+# .. setting_description: This setting should be set to the name of the user attribute property containing the LMS
+#      user id. Examples might be `id` or `lms_user_id`. If there is no property, leave the default value of None.
+#      This is used by JWT cookie authentication to verify that the (LMS) user id in the JWT is the same
+#      as the LMS user id for a service's session.
+VERIFY_LMS_USER_ID_PROPERTY_NAME = 'VERIFY_LMS_USER_ID_PROPERTY_NAME'

--- a/edx_rest_framework_extensions/settings.py
+++ b/edx_rest_framework_extensions/settings.py
@@ -18,6 +18,7 @@ from rest_framework_jwt.settings import api_settings
 from edx_rest_framework_extensions.config import (
     ENABLE_FORGIVING_JWT_COOKIES,
     ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE,
+    VERIFY_LMS_USER_ID_PROPERTY_NAME,
 )
 
 
@@ -35,6 +36,7 @@ DEFAULT_SETTINGS = {
     'JWT_PAYLOAD_MERGEABLE_USER_ATTRIBUTES': (),
     ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE: False,
     ENABLE_FORGIVING_JWT_COOKIES: False,
+    VERIFY_LMS_USER_ID_PROPERTY_NAME: None,
 }
 
 


### PR DESCRIPTION
**Description:**

Fixes a bug for any service other than the identity service
(LMS/CMS), where the session's local service user id would never
match the JWT LMS user id when compared.

- The custom attribute jwt_auth_mismatch_session_lms_user_id was
 renamed to jwt_auth_mismatch_session_lms_user_id to make this more
 clear.
- The setting EDX_DRF_EXTENSIONS[VERIFY_LMS_USER_ID_PROPERTY_NAME]
 was added to enable choosing the user object property that contains
 the LMS user id, if one exists. If this is set to None (the
 default), the check will use the lms_user_id property if it is
 found, and otherwise will skip this additional protection. In case
 of an unforeseen issue, use 'skip-check' to skip the check, even
 when there is an lms_user_id property.
- The custom attribute jwt_auth_get_lms_user_id_status was added to
 provide observability into the new functionality.

**BREAKING CHANGE**: The breaking change only affects services with
ENABLE_FORGIVING_JWT_COOKIES enabled. It now requires the new setting
VERIFY_LMS_USER_ID_PROPERTY_NAME to be set appropriately in order to
provide the existing Session vs JWT user id check. Note that only
LMS/CMS will likely need to set this value.

Part of DEPR:
https://github.com/openedx/edx-drf-extensions/issues/371

**Before merge checklist:**
- [x] For 2U: Set VERIFY_LMS_USER_ID_PROPERTY_NAME to 'id' in LMS.

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bump if needed
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
