### PR TITLE
docs: update .readthedocs.yaml

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,4 +1,4 @@
-# .readthedocs.yml
+# .readthedocs.yaml
 # Read the Docs configuration file
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
 
@@ -13,9 +13,8 @@ build:
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 
 python:
   install:
   - requirements: "requirements/docs.txt"
-  - method: pip
-    path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -18,3 +18,5 @@ sphinx:
 python:
   install:
   - requirements: "requirements/docs.txt"
+  - method: pip
+    path: .

--- a/docs/authentication.rst
+++ b/docs/authentication.rst
@@ -3,5 +3,5 @@ Authentication
 
 Authentication classes are used to associate a request with a user. Unless otherwise noted, all of the classes below adhere to the Django `REST Framework's API for authentication classes <http://www.django-rest-framework.org/api-guide/authentication/>`_.
 
-.. automodule:: edx_rest_framework_extensions.authentication
+.. automodule:: edx_rest_framework_extensions.auth
     :members:

--- a/docs/decisions/index.rst
+++ b/docs/decisions/index.rst
@@ -1,0 +1,9 @@
+Architectural Decision Records
+##############################
+
+.. toctree::
+   :glob:
+   :numbered:
+   :maxdepth: 1
+
+   ./*

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,3 +34,4 @@ Table of Contents
     permissions
     utils
     changelog
+    decisions/index

--- a/edx_rest_framework_extensions/middleware.py
+++ b/edx_rest_framework_extensions/middleware.py
@@ -17,16 +17,22 @@ class RequestCustomAttributesMiddleware(MiddlewareMixin):
 
     Possible custom attributes include:
         request_authenticated_user_set_in_middleware:
-            Example values: 'process_request', 'process_view', 'process_response',
-            or 'process_exception'. Attribute won't exist if user is not authenticated.
-        request_auth_type_guess: Example values include: no-user, unauthenticated,
-            jwt, bearer, other-token-type, jwt-cookie, or session-or-other
+            Example values: 'process_request', 'process_view', 'process_response', or 'process_exception'.
+
+            Attribute won't exist if user is not authenticated.
+
+        request_auth_type_guess:
+            Example values include: no-user, unauthenticated, jwt, bearer, other-token-type, jwt-cookie, or
+            session-or-other
+
             Note: These are just guesses because if a token was expired, for example,
-              the user could have been authenticated by some other means.
+            the user could have been authenticated by some other means.
+
         request_client_name: The client name from edx-rest-api-client calls.
-        request_referer
+        request_referer: The referrer for the request.
         request_user_agent: The user agent string from the request header.
         request_user_id: The user id of the request user.
+
         request_is_staff_or_superuser: `staff` or `superuser` depending on whether the
             user in the request is a django staff or superuser.
 


### PR DESCRIPTION
**Description:**

Following cookiecutter recommendations in this update: https://github.com/openedx/edx-drf-extensions/commit/bb2b78347d96145d56e5a3b671ad36e604be612e

- Rename .readthedocs.yml to .readthedocs.yaml
- Remove extra python install lines from edx-platform
- Add fail_on_warning to protect against doc issues

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Commits are squashed