### PR TITLE
feat: JWT vs session user check with username

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,20 @@ Change Log
 Unreleased
 ----------
 
+[9.1.0] - 2024-01-03
+--------------------
+
+Updated
+~~~~~~~
+
+* Simplified JWT cookie vs session user check by checking username instead of lms user id.
+
+  * Removed ``VERIFY_LMS_USER_ID_PROPERTY_NAME``, which is no longer needed.
+  * Removed custom attribute ``jwt_auth_get_lms_user_id_status``, since we no longer attempt to get the lms_user_id from the user object.
+  * Renames custom attribute ``jwt_auth_mismatch_session_lms_user_id`` to ``jwt_auth_mismatch_session_username``.
+  * Adds custom attribute ``jwt_auth_mismatch_jwt_cookie_username``.
+  * Adds custom attribute ``jwt_cookie_unsafe_decode_issue`` for when a JWT cookie cannot even be unsafely decoded.
+
 [9.0.1] - 2023-12-06
 --------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '9.0.1'  # pragma: no cover
+__version__ = '9.1.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/tests/test_authentication.py
@@ -36,7 +36,6 @@ from edx_rest_framework_extensions.auth.jwt.tests.utils import (
 from edx_rest_framework_extensions.config import (
     ENABLE_FORGIVING_JWT_COOKIES,
     ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE,
-    VERIFY_LMS_USER_ID_PROPERTY_NAME,
 )
 from edx_rest_framework_extensions.settings import get_setting
 from edx_rest_framework_extensions.tests import factories
@@ -237,97 +236,6 @@ class JwtAuthenticationTests(TestCase):
 
     @mock.patch.object(JwtAuthentication, 'enforce_csrf')
     @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
-    def test_authenticate_with_correct_jwt_cookie_and_mistmatched_lms_user_id(
-        self, mock_set_custom_attribute, mock_enforce_csrf
-    ):
-        """
-        Verify authenticate succeeds with a valid JWT cookie with a mismatched lms_user_id attribute.
-
-        Notes:
-        - When VERIFY_LMS_USER_ID_PROPERTY_NAME is None, it will also check for an `lms_user_id` attribute.
-        - This test mocks lms_user_id with a different value from the the JWT cookie LMS user id.
-        - At this time, we still allow authentication to succeed with the JWT cookie user, but we add observability.
-        - The other mismatch tests use the middleware and less mocking, but it was too difficult to add the
-          lms_user_id attribute.
-        """
-        request = RequestFactory().post('/')
-        request.META[USE_JWT_COOKIE_HEADER] = 'true'
-        request.COOKIES[jwt_cookie_name()] = self._get_test_jwt_token()
-        session_user = factories.UserFactory(id=111)
-
-        # set up request user with an lms_user_id attribute that will be compared to the JWT LMS user id
-        session_lms_user_id = 333
-        session_user.lms_user_id = session_lms_user_id
-        request.user = session_user
-
-        drf_request = Request(request)
-
-        assert JwtAuthentication().authenticate(drf_request)
-        mock_enforce_csrf.assert_called_with(drf_request)
-        is_forgiving_jwt_cookies_enabled = get_setting(ENABLE_FORGIVING_JWT_COOKIES)
-        mock_set_custom_attribute.assert_any_call('is_forgiving_jwt_cookies_enabled', is_forgiving_jwt_cookies_enabled)
-        mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'success-cookie')
-        set_custom_attribute_keys = [call.args[0] for call in mock_set_custom_attribute.call_args_list]
-        assert 'jwt_auth_with_django_request' not in set_custom_attribute_keys
-
-        if is_forgiving_jwt_cookies_enabled:
-            mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_session_lms_user_id', session_lms_user_id)
-            mock_set_custom_attribute.assert_any_call('jwt_auth_get_lms_user_id_status', 'id-found')
-        else:
-            assert 'jwt_auth_mismatch_session_lms_user_id' not in set_custom_attribute_keys
-            assert 'jwt_auth_get_lms_user_id_status' not in set_custom_attribute_keys
-
-    @mock.patch.object(JwtAuthentication, 'enforce_csrf')
-    @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
-    def test_authenticate_with_correct_jwt_cookie_and_skipped_check(
-        self, mock_set_custom_attribute, mock_enforce_csrf
-    ):
-        """
-        Verify authenticate succeeds with a valid JWT cookie and a skipped user id check.
-
-        Notes:
-        - When VERIFY_LMS_USER_ID_PROPERTY_NAME is 'skip-check', the `lms_user_id` attribute should be ignored.
-        - This mocks lms_user_id with a different value from the the JWT cookie LMS user id.
-        - The other mismatch tests use the middleware and less mocking, but it was too difficult to add the
-          lms_user_id attribute.
-        """
-        request = RequestFactory().post('/')
-        request.META[USE_JWT_COOKIE_HEADER] = 'true'
-        request.COOKIES[jwt_cookie_name()] = self._get_test_jwt_token()
-        session_user = factories.UserFactory(id=111)
-
-        # set up request user with an lms_user_id attribute that will be compared to the JWT LMS user id
-        session_lms_user_id = 333
-        session_user.lms_user_id = session_lms_user_id
-        request.user = session_user
-
-        drf_request = Request(request)
-
-        is_forgiving_jwt_cookies_enabled = get_setting(ENABLE_FORGIVING_JWT_COOKIES)
-        with override_settings(
-            EDX_DRF_EXTENSIONS={
-                ENABLE_FORGIVING_JWT_COOKIES: is_forgiving_jwt_cookies_enabled,
-                VERIFY_LMS_USER_ID_PROPERTY_NAME: 'skip-check',
-            },
-        ):
-            assert JwtAuthentication().authenticate(drf_request)
-
-            mock_enforce_csrf.assert_called_with(drf_request)
-            is_forgiving_jwt_cookies_enabled = get_setting(ENABLE_FORGIVING_JWT_COOKIES)
-            mock_set_custom_attribute.assert_any_call(
-                'is_forgiving_jwt_cookies_enabled', is_forgiving_jwt_cookies_enabled
-            )
-            mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'success-cookie')
-            set_custom_attribute_keys = [call.args[0] for call in mock_set_custom_attribute.call_args_list]
-            assert 'jwt_auth_with_django_request' not in set_custom_attribute_keys
-            assert 'jwt_auth_mismatch_session_lms_user_id' not in set_custom_attribute_keys
-            if is_forgiving_jwt_cookies_enabled:
-                mock_set_custom_attribute.assert_any_call('jwt_auth_get_lms_user_id_status', 'skip-check')
-            else:
-                assert 'jwt_auth_get_lms_user_id_status' not in set_custom_attribute_keys
-
-    @mock.patch.object(JwtAuthentication, 'enforce_csrf')
-    @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
     def test_authenticate_with_correct_jwt_cookie_and_django_request(
         self, mock_set_custom_attribute, mock_enforce_csrf
     ):
@@ -453,9 +361,8 @@ class JwtAuthenticationTests(TestCase):
     @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
     def test_authenticate_jwt_and_session_mismatch(self, mock_set_custom_attribute):
         """ Tests monitoring for JWT cookie when there is a session user mismatch """
-        session_lms_user_id = 111
-        session_user = factories.UserFactory(id=session_lms_user_id)
-        jwt_user = factories.UserFactory(id=222)
+        session_user = factories.UserFactory(id=111, username='session-name')
+        jwt_user = factories.UserFactory(id=222, username='jwt-name')
         self.client.cookies = SimpleCookie({
             jwt_cookie_name(): self._get_test_jwt_token(user=jwt_user),
         })
@@ -464,7 +371,6 @@ class JwtAuthenticationTests(TestCase):
         with override_settings(
             EDX_DRF_EXTENSIONS={
                 ENABLE_FORGIVING_JWT_COOKIES: is_forgiving_jwt_cookies_enabled,
-                VERIFY_LMS_USER_ID_PROPERTY_NAME: 'id',
             },
         ):
             self.client.force_login(session_user)
@@ -475,12 +381,15 @@ class JwtAuthenticationTests(TestCase):
             )
             mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'success-cookie')
             if is_forgiving_jwt_cookies_enabled:
-                mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_session_lms_user_id', session_lms_user_id)
-                mock_set_custom_attribute.assert_any_call('jwt_auth_get_lms_user_id_status', 'id-found')
+                mock_set_custom_attribute.assert_any_call(
+                    'jwt_cookie_lms_user_id', jwt_user.id  # pylint: disable=no-member
+                )
+                mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_session_username', session_user.username)
+                mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_jwt_cookie_username', jwt_user.username)
             else:
                 set_custom_attribute_keys = [call.args[0] for call in mock_set_custom_attribute.call_args_list]
-                assert 'jwt_auth_mismatch_session_lms_user_id' not in set_custom_attribute_keys
-                assert 'jwt_auth_get_lms_user_id_status' not in set_custom_attribute_keys
+                assert 'jwt_auth_mismatch_session_username' not in set_custom_attribute_keys
+                assert 'jwt_auth_mismatch_jwt_cookie_username' not in set_custom_attribute_keys
             assert response.status_code == 200
 
     @override_settings(
@@ -493,10 +402,8 @@ class JwtAuthenticationTests(TestCase):
     @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
     def test_authenticate_jwt_and_session_mismatch_bad_signature_cookie(self, mock_set_custom_attribute):
         """ Tests monitoring for JWT cookie with a bad signature when there is a session user mismatch """
-        session_lms_user_id = 111
-        session_user = factories.UserFactory(id=session_lms_user_id)
-        jwt_user_id = 222
-        jwt_user = factories.UserFactory(id=jwt_user_id)
+        session_user = factories.UserFactory(id=111, username='session-name')
+        jwt_user = factories.UserFactory(id=222, username='jwt-name')
         self.client.cookies = SimpleCookie({
             jwt_cookie_name(): self._get_test_jwt_token(user=jwt_user, is_valid_signature=False),
         })
@@ -505,7 +412,6 @@ class JwtAuthenticationTests(TestCase):
         with override_settings(
             EDX_DRF_EXTENSIONS={
                 ENABLE_FORGIVING_JWT_COOKIES: is_forgiving_jwt_cookies_enabled,
-                VERIFY_LMS_USER_ID_PROPERTY_NAME: 'id',
             },
         ):
             self.client.force_login(session_user)
@@ -514,16 +420,18 @@ class JwtAuthenticationTests(TestCase):
             mock_set_custom_attribute.assert_any_call(
                 'is_forgiving_jwt_cookies_enabled', is_forgiving_jwt_cookies_enabled
             )
-            mock_set_custom_attribute.assert_any_call('jwt_cookie_lms_user_id', jwt_user_id)
             if is_forgiving_jwt_cookies_enabled:
+                mock_set_custom_attribute.assert_any_call(
+                    'jwt_cookie_lms_user_id', jwt_user.id  # pylint: disable=no-member
+                )
                 mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'user-mismatch-failure')
-                mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_session_lms_user_id', session_lms_user_id)
-                mock_set_custom_attribute.assert_any_call('jwt_auth_get_lms_user_id_status', 'id-found')
+                mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_session_username', session_user.username)
+                mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_jwt_cookie_username', jwt_user.username)
             else:
                 mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'failed-cookie')
                 set_custom_attribute_keys = [call.args[0] for call in mock_set_custom_attribute.call_args_list]
-                assert 'jwt_auth_mismatch_session_lms_user_id' not in set_custom_attribute_keys
-                assert 'jwt_auth_get_lms_user_id_status' not in set_custom_attribute_keys
+                assert 'jwt_auth_mismatch_session_username' not in set_custom_attribute_keys
+                assert 'jwt_auth_mismatch_jwt_cookie_username' not in set_custom_attribute_keys
             assert response.status_code == 401
 
     @override_settings(
@@ -536,8 +444,7 @@ class JwtAuthenticationTests(TestCase):
     @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
     def test_authenticate_jwt_and_session_mismatch_invalid_cookie(self, mock_set_custom_attribute):
         """ Tests monitoring for invalid JWT cookie when there is a session user mismatch """
-        session_lms_user_id = 111
-        session_user = factories.UserFactory(id=session_lms_user_id)
+        session_user = factories.UserFactory(id=111, username='session-name')
         self.client.cookies = SimpleCookie({
             jwt_cookie_name(): 'invalid-cookie',
         })
@@ -546,7 +453,6 @@ class JwtAuthenticationTests(TestCase):
         with override_settings(
             EDX_DRF_EXTENSIONS={
                 ENABLE_FORGIVING_JWT_COOKIES: is_forgiving_jwt_cookies_enabled,
-                VERIFY_LMS_USER_ID_PROPERTY_NAME: 'id',
             },
         ):
             self.client.force_login(session_user)
@@ -555,16 +461,17 @@ class JwtAuthenticationTests(TestCase):
             mock_set_custom_attribute.assert_any_call(
                 'is_forgiving_jwt_cookies_enabled', is_forgiving_jwt_cookies_enabled
             )
-            mock_set_custom_attribute.assert_any_call('jwt_cookie_lms_user_id', 'decode-error')
             if is_forgiving_jwt_cookies_enabled:
+                mock_set_custom_attribute.assert_any_call('jwt_cookie_lms_user_id', None)
+                mock_set_custom_attribute.assert_any_call('jwt_cookie_unsafe_decode_issue', 'decode-error')
                 mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'user-mismatch-failure')
-                mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_session_lms_user_id', session_lms_user_id)
-                mock_set_custom_attribute.assert_any_call('jwt_auth_get_lms_user_id_status', 'id-found')
+                mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_session_username', session_user.username)
+                mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_jwt_cookie_username', None)
             else:
                 mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'failed-cookie')
                 set_custom_attribute_keys = [call.args[0] for call in mock_set_custom_attribute.call_args_list]
-                assert 'jwt_auth_mismatch_session_lms_user_id' not in set_custom_attribute_keys
-                assert 'jwt_auth_get_lms_user_id_status' not in set_custom_attribute_keys
+                assert 'jwt_auth_mismatch_session_username' not in set_custom_attribute_keys
+                assert 'jwt_auth_mismatch_jwt_cookie_username' not in set_custom_attribute_keys
             assert response.status_code == 401
 
     @override_settings(
@@ -586,7 +493,6 @@ class JwtAuthenticationTests(TestCase):
         with override_settings(
             EDX_DRF_EXTENSIONS={
                 ENABLE_FORGIVING_JWT_COOKIES: is_forgiving_jwt_cookies_enabled,
-                VERIFY_LMS_USER_ID_PROPERTY_NAME: 'id',
             },
         ):
             self.client.force_login(test_user)
@@ -597,10 +503,6 @@ class JwtAuthenticationTests(TestCase):
             )
             set_custom_attribute_keys = [call.args[0] for call in mock_set_custom_attribute.call_args_list]
             assert 'jwt_auth_mismatch_session_lms_user_id' not in set_custom_attribute_keys
-            if is_forgiving_jwt_cookies_enabled:
-                mock_set_custom_attribute.assert_any_call('jwt_auth_get_lms_user_id_status', 'id-found')
-            else:
-                assert 'jwt_auth_get_lms_user_id_status' not in set_custom_attribute_keys
             assert response.status_code == 200
 
     @override_settings(
@@ -625,7 +527,6 @@ class JwtAuthenticationTests(TestCase):
         mock_set_custom_attribute.assert_any_call('is_forgiving_jwt_cookies_enabled', is_forgiving_jwt_cookies_enabled)
         set_custom_attribute_keys = [call.args[0] for call in mock_set_custom_attribute.call_args_list]
         assert 'jwt_auth_mismatch_session_lms_user_id' not in set_custom_attribute_keys
-        assert 'jwt_auth_get_lms_user_id_status' not in set_custom_attribute_keys
         assert response.status_code == 200
 
     @override_settings(
@@ -640,20 +541,17 @@ class JwtAuthenticationTests(TestCase):
         ),
         ROOT_URLCONF='edx_rest_framework_extensions.auth.jwt.tests.test_authentication',
     )
-    @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.logger', autospec=True)
-    @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute', autospec=True)
-    def test_authenticate_no_lms_user_id_property_and_set_request_user(self, mock_set_custom_attribute, mock_logger):
+    @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
+    def test_authenticate_mismatch_with_set_request_user(self, mock_set_custom_attribute):
         """
-        Tests JWT cookie success when VERIFY_LMS_USER_ID_PROPERTY_NAME is not set and there is a request to set user.
+        Tests failure for JWT cookie when there is a session user mismatch with a request to set user.
 
         - This tests coordination between ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE in middleware and JwtAuthentication.
         - This test requires ENABLE_FORGIVING_JWT_COOKIES to get to ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE.
-        - Uses default of VERIFY_LMS_USER_ID_PROPERTY_NAME as None, and skips user id validation.
         - This test is kept with the rest of the JWT vs session user tests.
         """
-        session_user = factories.UserFactory(id=111)
-        jwt_user_id = 222
-        jwt_user = factories.UserFactory(id=jwt_user_id)
+        session_user = factories.UserFactory(id=111, username='session-name')
+        jwt_user = factories.UserFactory(id=222, username='jwt-name')
         jwt_header_payload, jwt_signature = self._get_test_jwt_token_payload_and_signature(user=jwt_user)
         # Cookie parts will be recombined by JwtAuthCookieMiddleware
         self.client.cookies = SimpleCookie({
@@ -663,167 +561,17 @@ class JwtAuthenticationTests(TestCase):
 
         self.client.force_login(session_user)
 
-        response = self.client.get(reverse('authenticated-view'))
-        assert response.status_code == 200
+        with self.assertRaises(JwtSessionUserMismatchError):
+            response = self.client.get(reverse('authenticated-view'))
+            assert response.status_code == 401
 
         # The case where forgiving JWTs is disabled is tested under other tests, including the middleware tests.
         mock_set_custom_attribute.assert_any_call('is_forgiving_jwt_cookies_enabled', True)
-        mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'success-cookie')
-        mock_set_custom_attribute.assert_any_call('jwt_auth_get_lms_user_id_status', 'not-configured')
-        mock_set_custom_attribute.assert_any_call('jwt_cookie_lms_user_id', jwt_user_id)
-        set_custom_attribute_keys = [call.args[0] for call in mock_set_custom_attribute.call_args_list]
-        assert 'jwt_auth_mismatch_session_lms_user_id' not in set_custom_attribute_keys
-        assert 'jwt_auth_failed' not in set_custom_attribute_keys
-        mock_logger.error.assert_not_called()
-
-    @override_settings(
-        EDX_DRF_EXTENSIONS={
-            ENABLE_FORGIVING_JWT_COOKIES: True,
-            ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE: True,
-            VERIFY_LMS_USER_ID_PROPERTY_NAME: 'unknown_property',
-        },
-        MIDDLEWARE=(
-            'django.contrib.sessions.middleware.SessionMiddleware',
-            'django.contrib.auth.middleware.AuthenticationMiddleware',
-            'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
-        ),
-        ROOT_URLCONF='edx_rest_framework_extensions.auth.jwt.tests.test_authentication',
-    )
-    @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.logger', autospec=True)
-    @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute', autospec=True)
-    def test_authenticate_unknown_user_id_property_and_set_request_user(self, mock_set_custom_attribute, mock_logger):
-        """
-        Tests JWT cookie success when VERIFY_LMS_USER_ID_PROPERTY_NAME is misconfigured with a request to set user.
-
-        - This tests coordination between ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE in middleware and JwtAuthentication.
-        - This test requires ENABLE_FORGIVING_JWT_COOKIES to get to ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE.
-        - The misconfigured VERIFY_LMS_USER_ID_PROPERTY_NAME will result in an error log.
-        - This test is kept with the rest of the JWT vs session user tests.
-        """
-        session_user = factories.UserFactory(id=111)
-        jwt_lms_user_id = 222
-        jwt_header_payload, jwt_signature = self._get_test_jwt_token_payload_and_signature(
-            user=session_user, lms_user_id=jwt_lms_user_id
+        mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_session_username', session_user.username)
+        mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_jwt_cookie_username', jwt_user.username)
+        mock_set_custom_attribute.assert_any_call(
+            'jwt_cookie_lms_user_id', jwt_user.id  # pylint: disable=no-member
         )
-        # Cookie parts will be recombined by JwtAuthCookieMiddleware
-        self.client.cookies = SimpleCookie({
-            jwt_cookie_header_payload_name(): jwt_header_payload,
-            jwt_cookie_signature_name(): jwt_signature,
-        })
-
-        self.client.force_login(session_user)
-
-        response = self.client.get(reverse('authenticated-view'))
-        assert response.status_code == 200
-
-        # The case where forgiving JWTs is disabled is tested under other tests, including the middleware tests.
-        mock_set_custom_attribute.assert_any_call('is_forgiving_jwt_cookies_enabled', True)
-        mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'success-cookie')
-        mock_set_custom_attribute.assert_any_call('jwt_auth_get_lms_user_id_status', 'misconfigured')
-        mock_set_custom_attribute.assert_any_call('jwt_cookie_lms_user_id', jwt_lms_user_id)
-        set_custom_attribute_keys = [call.args[0] for call in mock_set_custom_attribute.call_args_list]
-        assert 'jwt_auth_mismatch_session_lms_user_id' not in set_custom_attribute_keys
-        assert 'jwt_auth_failed' not in set_custom_attribute_keys
-
-        # assert for error log for misconfigured VERIFY_LMS_USER_ID_PROPERTY_NAME
-        assert 'unknown_property' in mock_logger.error.call_args_list[0][0][0]
-
-    @override_settings(
-        EDX_DRF_EXTENSIONS={
-            ENABLE_FORGIVING_JWT_COOKIES: True,
-            ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE: True,
-            VERIFY_LMS_USER_ID_PROPERTY_NAME: 'id',
-        },
-        MIDDLEWARE=(
-            'django.contrib.sessions.middleware.SessionMiddleware',
-            'django.contrib.auth.middleware.AuthenticationMiddleware',
-            'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
-        ),
-        ROOT_URLCONF='edx_rest_framework_extensions.auth.jwt.tests.test_authentication',
-    )
-    @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
-    def test_authenticate_user_id_property_and_set_request_user(self, mock_set_custom_attribute):
-        """
-        Tests failure for JWT cookie when there is a session user mismatch with id property and a request to set user.
-
-        - This tests coordination between ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE in middleware and JwtAuthentication.
-        - This test requires ENABLE_FORGIVING_JWT_COOKIES to get to ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE.
-        - Uses VERIFY_LMS_USER_ID_PROPERTY_NAME of 'id', as would be used by the identity service (LMS).
-        - This test is kept with the rest of the JWT vs session user tests.
-        """
-        session_lms_user_id = 111
-        session_user = factories.UserFactory(id=session_lms_user_id)
-        jwt_user_id = 222
-        jwt_user = factories.UserFactory(id=jwt_user_id)
-        jwt_header_payload, jwt_signature = self._get_test_jwt_token_payload_and_signature(user=jwt_user)
-        # Cookie parts will be recombined by JwtAuthCookieMiddleware
-        self.client.cookies = SimpleCookie({
-            jwt_cookie_header_payload_name(): jwt_header_payload,
-            jwt_cookie_signature_name(): jwt_signature,
-        })
-
-        self.client.force_login(session_user)
-
-        with self.assertRaises(JwtSessionUserMismatchError):
-            response = self.client.get(reverse('authenticated-view'))
-            assert response.status_code == 401
-
-        # The case where forgiving JWTs is disabled is tested under other tests, including the middleware tests.
-        mock_set_custom_attribute.assert_any_call('is_forgiving_jwt_cookies_enabled', True)
-        mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_session_lms_user_id', session_lms_user_id)
-        mock_set_custom_attribute.assert_any_call('jwt_auth_get_lms_user_id_status', 'id-found')
-        mock_set_custom_attribute.assert_any_call('jwt_cookie_lms_user_id', jwt_user_id)
-        mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'user-mismatch-enforced-failure')
-        mock_set_custom_attribute.assert_any_call('jwt_auth_failed', mock.ANY)
-
-    @override_settings(
-        EDX_DRF_EXTENSIONS={
-            ENABLE_FORGIVING_JWT_COOKIES: True,
-            ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE: True,
-            VERIFY_LMS_USER_ID_PROPERTY_NAME: 'username',
-        },
-        MIDDLEWARE=(
-            'django.contrib.sessions.middleware.SessionMiddleware',
-            'django.contrib.auth.middleware.AuthenticationMiddleware',
-            'edx_rest_framework_extensions.auth.jwt.middleware.JwtAuthCookieMiddleware',
-        ),
-        ROOT_URLCONF='edx_rest_framework_extensions.auth.jwt.tests.test_authentication',
-    )
-    @mock.patch('edx_rest_framework_extensions.auth.jwt.authentication.set_custom_attribute')
-    def test_authenticate_other_user_property_and_set_request_user(self, mock_set_custom_attribute):
-        """
-        Tests failure for JWT cookie with a session user mismatch with username property and a request to set user.
-
-        - This tests coordination between ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE in middleware and JwtAuthentication.
-        - This test requires ENABLE_FORGIVING_JWT_COOKIES to get to ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE.
-        - This test is kept with the rest of the JWT vs session user tests.
-        """
-        session_user_id = 222
-        # Some services introduce an lms_user_id property to the user, which ideally is what we'd be testing.
-        # However, we use the username property because it is simplifies the testing.
-        session_user_lms_id = '111'  # must be string because we are using username
-        session_user = factories.UserFactory(id=session_user_id, username=session_user_lms_id)
-        # In this test, the service's user id matches the JWT LMS user id, which ordinarily would never happen.
-        # However, for the purpose of this test, we want to ensure that this doesn't prevent the mismatch.
-        jwt_user_id = session_user_id
-        jwt_header_payload, jwt_signature = self._get_test_jwt_token_payload_and_signature(user=session_user)
-        # Cookie parts will be recombined by JwtAuthCookieMiddleware
-        self.client.cookies = SimpleCookie({
-            jwt_cookie_header_payload_name(): jwt_header_payload,
-            jwt_cookie_signature_name(): jwt_signature,
-        })
-
-        self.client.force_login(session_user)
-
-        with self.assertRaises(JwtSessionUserMismatchError):
-            response = self.client.get(reverse('authenticated-view'))
-            assert response.status_code == 401
-
-        # The case where forgiving JWTs is disabled is tested under other tests, including the middleware tests.
-        mock_set_custom_attribute.assert_any_call('is_forgiving_jwt_cookies_enabled', True)
-        mock_set_custom_attribute.assert_any_call('jwt_auth_mismatch_session_lms_user_id', session_user_lms_id)
-        mock_set_custom_attribute.assert_any_call('jwt_auth_get_lms_user_id_status', 'id-found')
-        mock_set_custom_attribute.assert_any_call('jwt_cookie_lms_user_id', jwt_user_id)
         mock_set_custom_attribute.assert_any_call('jwt_auth_result', 'user-mismatch-enforced-failure')
         mock_set_custom_attribute.assert_any_call('jwt_auth_failed', mock.ANY)
 
@@ -868,7 +616,6 @@ class JwtAuthenticationTests(TestCase):
         mock_set_custom_attribute.assert_any_call('jwt_cookie_lms_user_id', jwt_lms_user_id)
         set_custom_attribute_keys = [call.args[0] for call in mock_set_custom_attribute.call_args_list]
         assert 'jwt_auth_mismatch_session_lms_user_id' not in set_custom_attribute_keys
-        assert 'jwt_auth_get_lms_user_id_status' not in set_custom_attribute_keys
         assert response.status_code == 200
 
     def _get_test_jwt_token(self, user=None, is_valid_signature=True, lms_user_id=None):

--- a/edx_rest_framework_extensions/config.py
+++ b/edx_rest_framework_extensions/config.py
@@ -7,8 +7,7 @@ Application configuration constants and code.
 # .. toggle_default: False
 # .. toggle_description: Toggle for setting request.user with jwt cookie authentication. This makes the JWT cookie
 #      user available to middleware while processing the request, if the session user wasn't already available. This
-#      requires JwtAuthCookieMiddleware to work. It is recommended to set VERIFY_LMS_USER_ID_PROPERTY_NAME if possible
-#      when using this feature.
+#      requires JwtAuthCookieMiddleware to work.
 # .. toggle_use_cases: temporary
 # .. toggle_creation_date: 2019-10-15
 # .. toggle_target_removal_date: 2024-12-31
@@ -26,15 +25,3 @@ ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE = 'ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE
 # .. toggle_target_removal_date: 2023-10-01
 # .. toggle_tickets: https://github.com/openedx/edx-drf-extensions/issues/371
 ENABLE_FORGIVING_JWT_COOKIES = 'ENABLE_FORGIVING_JWT_COOKIES'
-
-# .. setting_name: EDX_DRF_EXTENSIONS[VERIFY_LMS_USER_ID_PROPERTY_NAME]
-# .. setting_default: None ('lms_user_id' if found)
-# .. setting_description: This setting should be set to the name of the user object property containing the LMS
-#      user id, if one exists. Examples might be 'id' or 'lms_user_id'. To enhance security and provide ease of use
-#      for this setting, if None is supplied, the property 'lms_user_id' will be used if found. In case of unforeseen
-#      issues using lms_user_id, the check can be fully disabled using 'skip-check' as the property name. The default
-#      was not set to 'lms_user_id' directly to avoid misconfiguration logging for services without an lms_user_id
-#      property. The property named by this setting will be used by JWT cookie authentication to verify that the (LMS)
-#      user id in the JWT is the same as the LMS user id for a service's session. This will cause failures in the case
-#      of forgiving cookies, and will simply be used for additional monitoring for successful cookie authentication.
-VERIFY_LMS_USER_ID_PROPERTY_NAME = 'VERIFY_LMS_USER_ID_PROPERTY_NAME'

--- a/edx_rest_framework_extensions/settings.py
+++ b/edx_rest_framework_extensions/settings.py
@@ -18,7 +18,6 @@ from rest_framework_jwt.settings import api_settings
 from edx_rest_framework_extensions.config import (
     ENABLE_FORGIVING_JWT_COOKIES,
     ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE,
-    VERIFY_LMS_USER_ID_PROPERTY_NAME,
 )
 
 
@@ -36,7 +35,6 @@ DEFAULT_SETTINGS = {
     'JWT_PAYLOAD_MERGEABLE_USER_ATTRIBUTES': (),
     ENABLE_SET_REQUEST_USER_FOR_JWT_COOKIE: False,
     ENABLE_FORGIVING_JWT_COOKIES: False,
-    VERIFY_LMS_USER_ID_PROPERTY_NAME: None,
 }
 
 


### PR DESCRIPTION
**Description:**

Simplified JWT cookie vs session user check by checking username instead of lms user id.

- Removed ``VERIFY_LMS_USER_ID_PROPERTY_NAME``, which is no longer needed.
- Removed custom attribute ``jwt_auth_get_lms_user_id_status``, since we no longer attempt to get the lms_user_id from the user object.
- Renames custom attribute ``jwt_auth_mismatch_session_lms_user_id`` to ``jwt_auth_mismatch_session_username``.
- Adds custom attribute ``jwt_auth_mismatch_jwt_cookie_username``.
- Adds custom attribute ``jwt_cookie_unsafe_decode_issue`` for when a JWT cookie cannot even be unsafely decoded.

**Issue:**

https://github.com/edx/edx-arch-experiments/issues/429

**Merge checklist:**
- [x] All reviewers approved
- [x] CI build is green
- [x] Version bump if needed
- [x] Changelog record added
- [x] Documentation updated (not only docstrings)
- [x] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.