### PR TITLE
fix: change base class for JwtAuthenticationError

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,11 @@ Change Log
 Unreleased
 ----------
 
+[10.2.0] - 2024-01-26
+---------------------
+
+* Subclasses base exception ``JwtAuthenticationError`` from Django Rest Framework's ``AuthenticationFailed`` exception, allowing ``JwtAuthenticationError`` to be recognized and handled by the default exception handler of the Django Rest Framework.
+
 [10.1.0] - 2024-01-26
 ---------------------
 

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '10.1.0'  # pragma: no cover
+__version__ = '10.2.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/auth/jwt/authentication.py
+++ b/edx_rest_framework_extensions/auth/jwt/authentication.py
@@ -24,7 +24,7 @@ from edx_rest_framework_extensions.settings import get_setting
 logger = logging.getLogger(__name__)
 
 
-class JwtAuthenticationError(Exception):
+class JwtAuthenticationError(exceptions.AuthenticationFailed):
     """
     Custom base class for all exceptions
     """


### PR DESCRIPTION
**Description:**

**Issue:** When JwtAuthentication class [raises](https://github.com/openedx/edx-drf-extensions/blob/master/edx_rest_framework_extensions/auth/jwt/authentication.py#L113-L119) `JwtUserEmailMismatchError` custom exception, it is not identified by the default exception handler of rest framework, therefore, returns `response = None` and hence we [get](https://www.django-rest-framework.org/api-guide/exceptions/#custom-exception-handling) `500 Server error`. 

**Fix:** This PR handles this issue by subclassing `JwtAuthenticationError` from the `AuthenticationFailed` exception which is a known exception and will be handled by the default exception handler.

**JIRA:**

[VAN-1694](https://openedx.atlassian.net/browse/VAN-1694)

**Additional Details**

* **Dependencies:**: List dependencies on other outstanding PRs, issues, etc.
* **Merge deadline:** List merge deadline (if any)
* **Testing instructions:** Provide non-trivial testing instructions
* **Author concerns:** List any concerns about this PR

**Reviewers:**
- [x] tag reviewer

**Merge checklist:**
- [ ] All reviewers approved
- [ ] CI build is green
- [ ] Version bump if needed
- [ ] Changelog record added
- [ ] Documentation updated (not only docstrings)
- [ ] Commits are squashed

**Post merge:**
- [ ] Create a tag
- [ ] Check new version is pushed to PyPi after tag-triggered build is
      finished.
- [ ] Delete working branch (if not needed anymore)
