### PR TITLE
feat: add OEP-66 queryset-scoping building blocks for DRF list endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,13 @@ Change Log
 Unreleased
 ----------
 
+[10.7.0] - 2026-07-30
+---------------------
+* Added a ``scoping`` module providing the OEP-66 record-visibility building
+  blocks for DRF list endpoints: ``ScopingPolicy`` (a ``typing.Protocol``, so
+  implementers need not inherit from it) and ``ScopedQuerysetMixin``, which
+  applies a configured policy in ``get_queryset()``.
+
 [10.6.0] - 2025-04-04
 ---------------------
 * Added Support for ``django 5.2``.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -32,6 +32,7 @@ Table of Contents
     authentication
     middleware
     permissions
+    scoping
     utils
     changelog
     decisions/index

--- a/docs/scoping.rst
+++ b/docs/scoping.rst
@@ -1,0 +1,8 @@
+Scoping
+=======
+OEP-66 record-visibility building blocks for DRF list endpoints: a
+``ScopingPolicy`` structural interface (a ``typing.Protocol``) and a
+``ScopedQuerysetMixin`` that applies a configured policy in ``get_queryset()``.
+
+.. automodule:: edx_rest_framework_extensions.scoping
+    :members:

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '10.6.0'  # pragma: no cover
+__version__ = '10.7.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/scoping.py
+++ b/edx_rest_framework_extensions/scoping.py
@@ -1,0 +1,87 @@
+"""
+OEP-66 queryset-scoping building blocks for DRF list endpoints.
+
+`OEP-66`_ ("Separating Authorization Concerns in List Endpoints") prescribes
+keeping three authorization concerns separate on a list endpoint, each handled
+by a dedicated layer:
+
+* **Endpoint access** -- DRF ``permission_classes`` (may this subject call the
+  endpoint at all?). Returns ``403`` when denied.
+* **Record visibility (queryset scoping)** -- a :class:`ScopingPolicy` applied
+  in ``get_queryset()`` by :class:`ScopedQuerysetMixin` (which rows may this
+  subject see?). Rows the subject may not see are simply absent from the
+  response; their absence is never a ``403``.
+* **User-driven filtering** -- e.g. a ``django-filter`` ``FilterSet`` (of the
+  visible rows, which did the caller ask for?). Narrows an already-authorized
+  queryset and must never widen it.
+
+This module provides the reusable record-visibility layer: a structural
+:class:`ScopingPolicy` interface and a :class:`ScopedQuerysetMixin` that applies
+it. It is deliberately engine-agnostic -- a policy typically resolves the
+subject's accessible scopes in one bulk lookup (for example openedx-authz
+``get_scopes_for_subject_and_permission``) and turns that scope set into a
+``WHERE`` clause, rather than running an ``enforce``-style check on every row --
+but any object that can filter a queryset for a subject may implement it.
+
+``ScopingPolicy`` is a :class:`typing.Protocol` rather than an abstract base
+class: implementers do not import or inherit anything, and type checkers verify
+conformance statically. :class:`ScopedQuerysetMixin` performs a lightweight
+duck-typed check (does the configured policy expose a callable ``scope``?) at
+runtime.
+
+This is *application-level* queryset scoping, not database-enforced
+`row-level security`_: it only constrains queries that go through the view's
+scoped queryset; code that queries the model directly is not protected by it.
+
+.. _OEP-66: https://docs.openedx.org/projects/openedx-proposals/en/latest/best-practices/oep-0066-bp-authorization.html
+.. _row-level security: https://www.postgresql.org/docs/current/ddl-rowsecurity.html
+"""
+from typing import Any, Optional, Protocol
+
+from django.core.exceptions import ImproperlyConfigured
+from django.db.models import QuerySet
+
+
+class ScopingPolicy(Protocol):
+    """
+    Structural interface for an OEP-66 record-visibility policy.
+
+    Any object exposing a compatible ``scope`` method satisfies this protocol --
+    implementers need not import or inherit from it. It documents the expected
+    interface for static type checkers; :class:`ScopedQuerysetMixin` verifies a
+    configured policy with a lightweight duck-typed check at runtime.
+
+    A policy must not re-implement access rules; it delegates to the platform's
+    authorization engine to resolve the subject's accessible scopes and
+    translates that answer into a queryset filter. Keeping it separate from the
+    view lets the same visibility rule be reused and unit-tested on its own.
+    """
+
+    def scope(self, queryset: QuerySet, subject: Any) -> QuerySet:
+        """Return ``queryset`` filtered to the rows visible to ``subject``."""
+
+
+class ScopedQuerysetMixin:
+    """
+    Applies :attr:`scoping_policy` to a DRF view's base queryset (OEP-66).
+
+    Mix into a ``GenericAPIView`` / ``ListAPIView`` (or ``GenericViewSet``) and
+    set :attr:`scoping_policy` to any object implementing the
+    :class:`ScopingPolicy` protocol. The mixin runs the policy on top of the
+    view's ``get_queryset()`` result so the ``list`` response contains only the
+    rows within the requesting subject's accessible scopes.
+    """
+
+    #: An object implementing the :class:`ScopingPolicy` protocol.
+    scoping_policy: Optional[ScopingPolicy] = None
+
+    def get_queryset(self) -> QuerySet:
+        """Return the base queryset scoped to the rows the requesting subject may see."""
+        queryset = super().get_queryset()
+        policy = self.scoping_policy
+        if not callable(getattr(policy, "scope", None)):
+            raise ImproperlyConfigured(
+                f"{type(self).__name__} uses ScopedQuerysetMixin but its scoping_policy does not "
+                f"implement the ScopingPolicy protocol (expected a callable 'scope(queryset, subject)' method)."
+            )
+        return policy.scope(queryset, self.request.user)

--- a/edx_rest_framework_extensions/tests/test_scoping.py
+++ b/edx_rest_framework_extensions/tests/test_scoping.py
@@ -1,0 +1,65 @@
+""" Tests for the OEP-66 queryset-scoping building blocks. """
+from unittest.mock import Mock, sentinel
+
+from django.core.exceptions import ImproperlyConfigured
+from django.test import TestCase
+
+from edx_rest_framework_extensions.scoping import ScopedQuerysetMixin
+
+
+class _RecordingPolicy:
+    """ A duck-typed policy (no inheritance) that records its ``scope`` call. """
+    def __init__(self, result):
+        self.result = result
+        self.calls = []
+
+    def scope(self, queryset, subject):
+        self.calls.append((queryset, subject))
+        return self.result
+
+
+class _NotAPolicy:
+    """ An object that does not expose a ``scope`` method. """
+
+
+class ScopedQuerysetMixinTests(TestCase):
+    """ Tests for ``ScopedQuerysetMixin.get_queryset``. """
+
+    def _make_view(self, policy, base_queryset=sentinel.base_qs, user=sentinel.user):
+        """ Build a mixin-based view whose ``super().get_queryset()`` yields ``base_queryset``. """
+        base_request = Mock(user=user)
+
+        class _BaseView:
+            def get_queryset(self):
+                return base_queryset
+
+        class _View(ScopedQuerysetMixin, _BaseView):
+            request = base_request
+            scoping_policy = policy
+
+        return _View()
+
+    def test_applies_policy_to_base_queryset(self):
+        # A plain duck-typed policy (no import/inheritance) is accepted and applied.
+        policy = _RecordingPolicy(result=sentinel.scoped_qs)
+        view = self._make_view(policy)
+
+        result = view.get_queryset()
+
+        self.assertIs(result, sentinel.scoped_qs)
+        self.assertEqual(policy.calls, [(sentinel.base_qs, sentinel.user)])
+
+    def test_missing_policy_raises_improperly_configured(self):
+        view = self._make_view(policy=None)
+        with self.assertRaises(ImproperlyConfigured):
+            view.get_queryset()
+
+    def test_policy_without_scope_raises_improperly_configured(self):
+        view = self._make_view(policy=_NotAPolicy())
+        with self.assertRaises(ImproperlyConfigured):
+            view.get_queryset()
+
+    def test_policy_with_non_callable_scope_raises_improperly_configured(self):
+        view = self._make_view(policy=Mock(scope="not-callable"))
+        with self.assertRaises(ImproperlyConfigured):
+            view.get_queryset()


### PR DESCRIPTION
Add a `scoping` module providing the reusable record-visibility layer from OEP-66 ("Separating Authorization Concerns in List Endpoints") so DRF list endpoints across the platform and its plugins can share it:

  * ScopingPolicy — a typing.Protocol (structural interface, not an ABC). Implementers need not import or inherit anything; type checkers verify conformance statically. The single method is `scope(queryset, subject)` (subject, not user, to match the openedx-authz subject-based model).
  * ScopedQuerysetMixin — applies a view's `scoping_policy` on top of `get_queryset()`. It duck-type-checks that the policy exposes a callable `scope` and raises ImproperlyConfigured otherwise.

Using a Protocol + duck-typed runtime check (rather than an ABC) avoids inheritance coupling across repos, keeps interface changes resilient, and lets consumers implement the policy without a hard dependency on this base.

Bumps version to 10.7.0 and adds unit tests.

