### PR TITLE
feat: add REST API convention building blocks for Open edX endpoints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -47,6 +47,11 @@ this package. No new dependencies.
   (``COURSE_KEY_LOOKUP_REGEX``, ``USAGE_KEY_LOOKUP_REGEX``).
 * Added a ``testing`` module with ``assert_error_envelope()`` for asserting
   ADR 0029 envelopes in consumer test suites.
+* Added a ``url_converters`` module (ADR 0038 URL structure): the shared
+  opaque-key path converters ``CourseKeyConverter`` and ``UsageKeyConverter``
+  (non-deprecated keys only — deprecated ``Org/Course/Run`` / ``i4x://`` forms
+  404), plus ``register_url_converters()`` to register them once per service
+  as ``<course_key:...>`` / ``<usage_key:...>``.
 
 [10.7.0] - 2026-07-30
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,42 @@ Change Log
 Unreleased
 ----------
 
+[10.8.0] - 2026-08-28
+---------------------
+Added the reusable core of edx-platform's FC-0118 REST API conventions
+(edx-platform ADR 0039, "Extract the REST API Reference Implementation into a
+Shared Library"), so plugins and IDAs can follow the conventions by installing
+this package. No new dependencies.
+
+* Added an ``errors`` module (ADR 0029 standardized error responses):
+
+  * ``standardized_error_exception_handler`` — DRF exception handler returning
+    the standardized JSON error envelope. Its platform coupling is inverted:
+    it delegates to a base handler resolved from the new
+    ``EDX_DRF_EXTENSIONS['STANDARDIZED_ERROR_BASE_HANDLER']`` setting (dotted
+    path or callable, default DRF's ``exception_handler``), so services keep
+    their own error monitoring.
+  * ``Conflict`` — HTTP 409 ``APIException``.
+  * Envelope formatters: ``build_error_envelope``, ``flatten_detail``,
+    ``normalize_validation_errors``.
+  * The error-type URI catalog (``ERROR_TYPE_BASE_URI``, ``error_type_uri``,
+    ``classify_error``) and its extension helper ``register_error_type``.
+  * ``ErrorResponseSerializer`` — plain-DRF serializer documenting the
+    envelope in OpenAPI response declarations.
+
+* Added a ``mixins`` module with ``StandardizedErrorMixin``, the per-view
+  opt-in for the ADR 0029 handler.
+* Added a ``shaping`` module (ADR 0036 response shaping): ``project()``
+  (top-level field selection, e.g. ``?fields=a,b``) and ``MinimalViewMixin``
+  (the ``?view=minimal`` response preset).
+* Added ``paginate_manually()`` and ``IterablePaginationMixin`` to
+  ``paginators`` (ADR 0032 pagination envelope for endpoints outside DRF's
+  generic ``list`` machinery).
+* Added a ``routers`` module with opaque-key ``lookup_value_regex`` constants
+  (``COURSE_KEY_LOOKUP_REGEX``, ``USAGE_KEY_LOOKUP_REGEX``).
+* Added a ``testing`` module with ``assert_error_envelope()`` for asserting
+  ADR 0029 envelopes in consumer test suites.
+
 [10.7.0] - 2026-07-30
 ---------------------
 * Added a ``scoping`` module providing the OEP-66 record-visibility building

--- a/docs/errors.rst
+++ b/docs/errors.rst
@@ -1,0 +1,12 @@
+Errors
+======
+ADR 0029 standardized error responses: the exception handler and its envelope
+formatters, the ``Conflict`` exception, the error-type URI catalog with its
+``register_error_type`` extension helper, and the ``ErrorResponseSerializer``
+that documents the envelope in OpenAPI schemas. The handler delegates to a
+base handler resolved from the
+``EDX_DRF_EXTENSIONS['STANDARDIZED_ERROR_BASE_HANDLER']`` setting, so services
+keep their own error-monitoring behavior.
+
+.. automodule:: edx_rest_framework_extensions.errors
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ Table of Contents
     scoping
     shaping
     testing
+    url_converters
     utils
     changelog
     decisions/index

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,9 +30,14 @@ Table of Contents
 
     settings
     authentication
+    errors
     middleware
+    mixins
     permissions
+    routers
     scoping
+    shaping
+    testing
     utils
     changelog
     decisions/index

--- a/docs/mixins.rst
+++ b/docs/mixins.rst
@@ -1,0 +1,8 @@
+Mixins
+======
+DRF view mixins implementing the Open edX REST API conventions, currently
+``StandardizedErrorMixin`` — the per-view opt-in for the ADR 0029
+standardized error-response handler.
+
+.. automodule:: edx_rest_framework_extensions.mixins
+    :members:

--- a/docs/routers.rst
+++ b/docs/routers.rst
@@ -1,0 +1,7 @@
+Routers
+=======
+Opaque-key ``lookup_value_regex`` constants for DRF routers, so ViewSets keyed
+by course or usage keys share one spelling of the URL-delimiting patterns.
+
+.. automodule:: edx_rest_framework_extensions.routers
+    :members:

--- a/docs/shaping.rst
+++ b/docs/shaping.rst
@@ -1,0 +1,8 @@
+Shaping
+=======
+ADR 0036 response-shaping helpers: ``project()`` for top-level field
+selection (``?fields=a,b``) and ``MinimalViewMixin`` for the
+``?view=minimal`` response preset.
+
+.. automodule:: edx_rest_framework_extensions.shaping
+    :members:

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -1,0 +1,8 @@
+Testing
+=======
+Test helpers for the REST API conventions, currently
+``assert_error_envelope()`` — a single assertion that a response carries a
+well-formed ADR 0029 error envelope.
+
+.. automodule:: edx_rest_framework_extensions.testing
+    :members:

--- a/docs/url_converters.rst
+++ b/docs/url_converters.rst
@@ -1,0 +1,8 @@
+URL Converters
+==============
+Shared opaque-key URL path converters (edx-platform ADR 0038, rule 9), so
+conforming API routes resolve course and usage keys once, hand views parsed
+keys, and turn malformed or deprecated keys into consistent 404s.
+
+.. automodule:: edx_rest_framework_extensions.url_converters
+    :members:

--- a/edx_rest_framework_extensions/__init__.py
+++ b/edx_rest_framework_extensions/__init__.py
@@ -1,3 +1,3 @@
 """ edx Django REST Framework extensions. """
 
-__version__ = '10.7.0'  # pragma: no cover
+__version__ = '10.8.0'  # pragma: no cover

--- a/edx_rest_framework_extensions/errors.py
+++ b/edx_rest_framework_extensions/errors.py
@@ -1,0 +1,282 @@
+"""
+Standardized error responses for Open edX REST APIs (ADR 0029).
+
+This module is the reusable core of edx-platform's
+``docs/decisions/0029-standardize-error-responses`` implementation: a DRF
+exception handler that reshapes error responses into a single JSON envelope,
+the building blocks it is made of, and a plain-DRF serializer that documents
+the envelope in OpenAPI schemas.
+
+The envelope shape is::
+
+    {
+        "type":     "https://docs.openedx.org/errors/<slug>",
+        "title":    "<Human-readable title>",
+        "status":   <HTTP status code>,
+        "detail":   "<flattened error message>",
+        "instance": "<request path>"
+    }
+
+with two optional keys: ``user_message`` (when the raised exception carries a
+``user_message`` attribute) and ``errors`` (per-field details, on
+``ValidationError`` only).
+
+Wiring options:
+
+* Per view — mix :class:`~edx_rest_framework_extensions.mixins.StandardizedErrorMixin`
+  into the view (or use it via a base class).
+* Service-wide — point DRF at the handler directly::
+
+      REST_FRAMEWORK = {
+          "EXCEPTION_HANDLER":
+              "edx_rest_framework_extensions.errors.standardized_error_exception_handler",
+      }
+
+Dependency inversion — the handler delegates to a *base* exception handler
+before shaping the envelope, so services can keep their own error-monitoring
+behavior. It defaults to DRF's own ``exception_handler``; override it with the
+``STANDARDIZED_ERROR_BASE_HANDLER`` key of the ``EDX_DRF_EXTENSIONS`` setting
+(a dotted path or a callable). edx-platform, for example, sets::
+
+    EDX_DRF_EXTENSIONS = {
+        "STANDARDIZED_ERROR_BASE_HANDLER":
+            "openedx.core.lib.request_utils.ignored_error_exception_handler",
+    }
+"""
+from django.utils.module_loading import import_string
+from rest_framework import serializers
+from rest_framework.exceptions import (
+    APIException,
+    AuthenticationFailed,
+    NotAuthenticated,
+    NotFound,
+    PermissionDenied,
+    Throttled,
+    ValidationError,
+)
+from rest_framework.response import Response
+from rest_framework.views import exception_handler as drf_exception_handler
+
+from edx_rest_framework_extensions.settings import get_setting
+
+
+# ---------------------------------------------------------------------------
+# Error-type URI catalog
+# ---------------------------------------------------------------------------
+
+#: Base URI under which every ADR 0029 error-type slug is published.
+ERROR_TYPE_BASE_URI = "https://docs.openedx.org/errors/"
+
+
+def error_type_uri(slug):
+    """Return the full ADR 0029 error-type URI for ``slug`` (e.g. ``"authn"``)."""
+    return ERROR_TYPE_BASE_URI + slug
+
+
+class Conflict(APIException):
+    """HTTP 409 Conflict — ADR 0029."""
+
+    status_code = 409
+    default_detail = "A conflict occurred."
+    default_code = "conflict"
+
+
+# The built-in catalog, checked in order with ``isinstance`` so subclasses of a
+# cataloged exception inherit its slug and title. ``NotAuthenticated`` and
+# ``AuthenticationFailed`` share the "authn" slug but carry distinct titles.
+_BUILTIN_ERROR_TYPES = (
+    (NotAuthenticated, "authn", "Authentication Required"),
+    (AuthenticationFailed, "authn", "Authentication Failed"),
+    (PermissionDenied, "authz", "Permission Denied"),
+    (NotFound, "not-found", "Not Found"),
+    (ValidationError, "validation", "Validation Error"),
+    (Throttled, "rate-limited", "Too Many Requests"),
+    (Conflict, "conflict", "Conflict"),
+)
+
+# Extension registrations, most recent first. Checked before the built-ins so
+# a registration can also specialize a cataloged exception's subclass.
+_registered_error_types = []
+
+#: Slug and title used when an exception matches nothing in the catalog.
+INTERNAL_ERROR_SLUG = "internal"
+INTERNAL_ERROR_TITLE = "Internal Server Error"
+
+
+def register_error_type(exception_class, slug, title):
+    """
+    Extend the ADR 0029 error-type catalog with a custom exception class.
+
+    After registration, any raised instance of ``exception_class`` (or a
+    subclass) is enveloped with ``type`` ``error_type_uri(slug)`` and ``title``
+    ``title``. Registrations are consulted most-recent-first and take
+    precedence over the built-in catalog, so registering a subclass of a
+    cataloged exception specializes it.
+
+    Arguments:
+        exception_class (type): the exception class to classify.
+        slug (str): the error-type slug, appended to :data:`ERROR_TYPE_BASE_URI`.
+        title (str): the human-readable envelope title.
+    """
+    _registered_error_types.insert(0, (exception_class, slug, title))
+
+
+def classify_error(exc):
+    """
+    Return the ``(slug, title)`` catalog entry for the exception ``exc``.
+
+    Falls back to ``(INTERNAL_ERROR_SLUG, INTERNAL_ERROR_TITLE)`` when the
+    exception matches neither a registered nor a built-in catalog entry.
+    """
+    for exception_class, slug, title in tuple(_registered_error_types) + _BUILTIN_ERROR_TYPES:
+        if isinstance(exc, exception_class):
+            return slug, title
+    return INTERNAL_ERROR_SLUG, INTERNAL_ERROR_TITLE
+
+
+# ---------------------------------------------------------------------------
+# Envelope formatters
+# ---------------------------------------------------------------------------
+
+def flatten_detail(data):
+    """Extract a single string detail message from a DRF response data payload."""
+    if isinstance(data, str):
+        return data
+    if isinstance(data, dict) and "detail" in data:
+        return str(data["detail"])
+    if isinstance(data, list) and data:
+        return str(data[0])
+    return str(data)
+
+
+def normalize_validation_errors(detail):
+    """Convert DRF validation error detail into a consistent per-field dict."""
+    if isinstance(detail, dict):
+        return {
+            field: [str(e) for e in (errs if isinstance(errs, list) else [errs])]
+            for field, errs in detail.items()
+        }
+    if isinstance(detail, list):
+        return {"non_field_errors": [str(e) for e in detail]}
+    return {"non_field_errors": [str(detail)]}
+
+
+def build_error_envelope(exc, response, request=None):
+    """
+    Build the ADR 0029 error envelope for ``exc``.
+
+    Arguments:
+        exc (Exception): the exception the view raised.
+        response (rest_framework.response.Response): the response produced by
+            the base exception handler; supplies the status code and the raw
+            error data that ``detail`` is flattened from.
+        request: the request being handled, if available; supplies ``instance``.
+
+    Returns:
+        dict: the envelope, ready to be assigned to ``response.data``.
+    """
+    slug, title = classify_error(exc)
+    body = {
+        "type": error_type_uri(slug),
+        "title": title,
+        "status": response.status_code,
+        "detail": flatten_detail(response.data),
+    }
+    if request:
+        body["instance"] = request.path
+    if hasattr(exc, "user_message") and exc.user_message:
+        body["user_message"] = exc.user_message
+    if isinstance(exc, ValidationError) and hasattr(exc, "detail"):
+        body["errors"] = normalize_validation_errors(exc.detail)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Exception handler (with the base-handler dependency inversion)
+# ---------------------------------------------------------------------------
+
+def _base_exception_handler():
+    """
+    Resolve the exception handler this one delegates to before shaping the envelope.
+
+    Defaults to DRF's ``exception_handler``. Services override it with the
+    ``STANDARDIZED_ERROR_BASE_HANDLER`` key of the ``EDX_DRF_EXTENSIONS``
+    setting — either a dotted import path or a callable — to keep their own
+    error-monitoring behavior in the loop.
+    """
+    handler = get_setting("STANDARDIZED_ERROR_BASE_HANDLER")
+    if handler is None:
+        return drf_exception_handler
+    if callable(handler):
+        return handler
+    return import_string(handler)
+
+
+def standardized_error_exception_handler(exc, context):
+    """
+    ADR 0029 — DRF exception handler returning the standardized error envelope.
+
+    Delegates to the base handler (see :func:`_base_exception_handler`) and
+    reformats its response via :func:`build_error_envelope`. When the base
+    handler declines to handle the exception (returns ``None``, DRF's behavior
+    for non-``APIException`` errors), a generic ``internal`` 500 envelope is
+    returned instead of re-raising.
+    """
+    response = _base_exception_handler()(exc, context)
+    request = context.get("request")
+
+    if response is None:
+        body = {
+            "type": error_type_uri(INTERNAL_ERROR_SLUG),
+            "title": INTERNAL_ERROR_TITLE,
+            "status": 500,
+            "detail": "An unexpected error occurred. Please try again later.",
+        }
+        if request:
+            body["instance"] = request.path
+        return Response(body, status=500)
+
+    response.data = build_error_envelope(exc, response, request=request)
+    response["Content-Type"] = "application/json"
+    return response
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI documentation serializer
+# ---------------------------------------------------------------------------
+
+class ErrorResponseSerializer(serializers.Serializer):  # pylint: disable=abstract-method
+    """
+    Plain-DRF serializer describing the ADR 0029 error envelope.
+
+    Intended for OpenAPI response declarations so error responses are
+    documented with their real shape, e.g. with drf-spectacular::
+
+        @extend_schema(responses={
+            200: MyResourceSerializer,
+            404: ErrorResponseSerializer,
+        })
+
+    It is a documentation serializer: nothing deserializes through it, so it
+    implements no ``create``/``update``.
+    """
+
+    type = serializers.URLField(
+        help_text="Error-type URI (https://docs.openedx.org/errors/<slug>).",
+    )
+    title = serializers.CharField(help_text="Human-readable error title.")
+    status = serializers.IntegerField(help_text="HTTP status code, repeated from the response.")
+    detail = serializers.CharField(help_text="Flattened human-readable error message.")
+    instance = serializers.CharField(
+        required=False,
+        help_text="Path of the request that produced the error.",
+    )
+    user_message = serializers.CharField(
+        required=False,
+        help_text="End-user-facing message, when the raising code supplied one.",
+    )
+    errors = serializers.DictField(
+        child=serializers.ListField(child=serializers.CharField()),
+        required=False,
+        help_text="Per-field validation errors (validation errors only).",
+    )

--- a/edx_rest_framework_extensions/mixins.py
+++ b/edx_rest_framework_extensions/mixins.py
@@ -1,0 +1,25 @@
+"""
+DRF view mixins implementing the Open edX REST API conventions.
+"""
+from edx_rest_framework_extensions.errors import standardized_error_exception_handler
+
+
+class StandardizedErrorMixin:
+    """
+    Opt-in mixin that routes DRF exceptions on this view through the ADR 0029
+    standardized error-response handler
+    (:func:`edx_rest_framework_extensions.errors.standardized_error_exception_handler`).
+
+    DRF's :class:`rest_framework.views.APIView` calls ``self.get_exception_handler``
+    inside ``handle_exception``; overriding that method here lets the view
+    return the standardized envelope while other endpoints continue to use
+    whichever handler the project-wide ``EXCEPTION_HANDLER`` setting points at.
+
+    Usage::
+
+        class MyViewSet(StandardizedErrorMixin, viewsets.ViewSet):
+            ...
+    """
+
+    def get_exception_handler(self):
+        return standardized_error_exception_handler

--- a/edx_rest_framework_extensions/paginators.py
+++ b/edx_rest_framework_extensions/paginators.py
@@ -1,5 +1,6 @@
 """ Paginatator methods for edX API implementations."""
 
+from django.core.exceptions import ImproperlyConfigured
 from django.core.paginator import InvalidPage, Paginator
 from django.http import Http404
 from rest_framework import pagination
@@ -30,6 +31,84 @@ class DefaultPagination(pagination.PageNumberPagination):
             'start': (self.page.number - 1) * self.get_page_size(self.request),
             'results': data
         })
+
+
+def paginate_manually(request, items, serialize, pagination_class=DefaultPagination, view=None):
+    """
+    Paginate ``items`` by hand and return the paginated ``Response``.
+
+    ADR 0032 requires the standard pagination envelope even on endpoints whose
+    data is not a queryset flowing through DRF's generic ``list`` machinery —
+    a plain ``ViewSet`` action, or results assembled from an API call. This is
+    the shared spelling of the paginate-serialize-respond sequence those
+    endpoints otherwise hand-write.
+
+    Arguments:
+        request: the DRF request (supplies the ``page``/``page_size`` params).
+        items: a sequence or queryset (anything Django's ``Paginator`` can
+            ``len()`` and slice; a bare generator will not do).
+        serialize: callable receiving the page's items (a list) and returning
+            their serialized representation.
+        pagination_class: the DRF pagination class to use; defaults to
+            :class:`DefaultPagination`.
+        view: the view handling the request, when there is one (passed through
+            to ``paginate_queryset``).
+
+    Returns:
+        rest_framework.response.Response: the paginated response.
+    """
+    paginator = pagination_class()
+    page = paginator.paginate_queryset(items, request, view=view)
+    return paginator.get_paginated_response(serialize(page))
+
+
+class IterablePaginationMixin:
+    """
+    ADR 0032 pagination for views outside DRF's generic ``list`` machinery.
+
+    Mix into a ``ViewSet`` or ``APIView`` whose handler builds its own item
+    sequence (rather than exposing a queryset through ``GenericAPIView``), and
+    return ``self.paginate_iterable(request, items)`` from the handler::
+
+        class EnrollmentViewSet(IterablePaginationMixin, viewsets.ViewSet):
+            serializer_class = CourseEnrollmentSerializer
+
+            def list(self, request):
+                enrollments = ops.list_enrollments_for_user(...)
+                return self.paginate_iterable(request, enrollments)
+
+    The view's ``pagination_class`` controls the envelope; it defaults to
+    :class:`DefaultPagination` (the ADR 0032 seven-field envelope).
+    """
+
+    #: The DRF pagination class applied by :meth:`paginate_iterable`.
+    pagination_class = DefaultPagination
+
+    def paginate_iterable(self, request, items, serialize=None):
+        """
+        Paginate ``items`` (a sequence or queryset) and return the paginated
+        ``Response``.
+
+        ``serialize`` defaults to ``self.get_serializer(page, many=True).data``,
+        matching DRF's generic views; pass a callable to serialize differently.
+        """
+        if self.pagination_class is None:
+            raise ImproperlyConfigured(
+                f"{type(self).__name__} uses IterablePaginationMixin but its 'pagination_class' is None."
+            )
+        if serialize is None:
+            if not callable(getattr(self, "get_serializer", None)):
+                raise ImproperlyConfigured(
+                    f"{type(self).__name__}.paginate_iterable needs either a 'serialize' argument "
+                    f"or a 'get_serializer' method on the view."
+                )
+
+            def serialize(page):
+                return self.get_serializer(page, many=True).data
+
+        return paginate_manually(
+            request, items, serialize, pagination_class=self.pagination_class, view=self,
+        )
 
 
 class NamespacedPageNumberPagination(pagination.PageNumberPagination):

--- a/edx_rest_framework_extensions/routers.py
+++ b/edx_rest_framework_extensions/routers.py
@@ -1,0 +1,29 @@
+"""
+Opaque-key ``lookup_value_regex`` constants for DRF routers.
+
+DRF's routers default a ViewSet's ``lookup_value_regex`` to ``[^/.]+``, which
+cannot match Open edX opaque keys: old-style course keys contain slashes
+(``edX/DemoX/Demo_2014``) and new-style keys contain dots in the run or block
+id. Every router-registered ViewSet keyed by an opaque key therefore needs an
+explicit ``lookup_value_regex``, and edx-platform's pilot APIs each hand-wrote
+their own. These constants are the shared spellings, matching the patterns
+``openedx/core/constants.py`` has used in URL routes for years (with capturing
+groups made non-capturing, as router regexes are embedded inside the named
+lookup group)::
+
+    class CourseDetailsViewSet(viewsets.GenericViewSet):
+        lookup_field = "course_key"
+        lookup_value_regex = COURSE_KEY_LOOKUP_REGEX
+
+The patterns are deliberately permissive — they delimit the key within the URL
+path; real validation belongs to ``opaque_keys`` (``CourseKey.from_string`` /
+``UsageKey.from_string``) in the view.
+"""
+
+#: Matches new-style (``course-v1:org+course+run``) and old-style
+#: (``org/course/run``) course keys.
+COURSE_KEY_LOOKUP_REGEX = r"[^/+]+(?:/|\+)[^/+]+(?:/|\+)[^/?]+"
+
+#: Matches new-style (``block-v1:...+type@...+block@...``) and old-style
+#: (``i4x://org/course/category/name``) usage keys.
+USAGE_KEY_LOOKUP_REGEX = r"(?:i4x://?[^/]+/[^/]+/[^/]+/[^@]+(?:@[^/]+)?)|(?:[^/]+)"

--- a/edx_rest_framework_extensions/settings.py
+++ b/edx_rest_framework_extensions/settings.py
@@ -36,6 +36,12 @@ DEFAULT_SETTINGS = {
     },
 
     'OAUTH2_USER_INFO_URL': None,
+
+    # Exception handler that edx_rest_framework_extensions.errors
+    # .standardized_error_exception_handler delegates to before shaping the
+    # ADR 0029 envelope. A dotted import path or a callable; None means DRF's
+    # own rest_framework.views.exception_handler.
+    'STANDARDIZED_ERROR_BASE_HANDLER': None,
 }
 
 

--- a/edx_rest_framework_extensions/shaping.py
+++ b/edx_rest_framework_extensions/shaping.py
@@ -1,0 +1,116 @@
+"""
+Response-shaping helpers for Open edX REST APIs (ADR 0036).
+
+edx-platform's ``docs/decisions/0036`` lets clients opt out of heavy response
+payloads in two standard ways, both implemented here:
+
+* ``?fields=a,b,c`` — keep only the named top-level keys of a serialized
+  object (:func:`project`).
+* ``?view=minimal`` — replace each serialized object with a view-defined
+  minimal representation (:class:`MinimalViewMixin`).
+
+Both are *shaping* helpers: they operate on already-serialized data (dicts and
+lists of dicts) immediately before the response is returned, so the default
+response shape — and therefore backwards compatibility — is untouched unless
+the client asks.
+"""
+from django.core.exceptions import ImproperlyConfigured
+
+
+def project(data, fields):
+    """
+    Return a new dict containing only the top-level keys of ``data`` named in
+    ``fields``.
+
+    Arguments:
+        data: a ``dict`` (typically ``serializer.data``). Anything else is
+            returned untouched.
+        fields: an iterable of field names, or a comma-separated string (for
+            example the raw value of a ``?fields=`` query parameter). Falsy →
+            no filtering (``data`` is returned unchanged).
+
+    Returns:
+        A new ``dict`` containing only the requested top-level keys, or the
+        original ``data`` when filtering is not applicable.
+
+    Note:
+        Only top-level keys are honoured. Dotted paths (``fields=children.x``)
+        are stripped to their first segment (``children``) — full dotted-path
+        traversal is intentionally not implemented, per the ADR 0036 guidance
+        to reject silent over-fetching via that syntax.
+    """
+    if not fields or not isinstance(data, dict):
+        return data
+    names = fields.split(",") if isinstance(fields, str) else fields
+    wanted = {str(name).strip().split(".", 1)[0] for name in names if str(name).strip()}
+    if not wanted:
+        return data
+    return {key: value for key, value in data.items() if key in wanted}
+
+
+class MinimalViewMixin:
+    """
+    ADR 0036 ``?view=minimal`` support for DRF views.
+
+    Mix into a view and either set :attr:`minimal_fields` (the projection
+    applied to each serialized object) or override
+    :meth:`to_minimal_representation` for shapes a plain projection cannot
+    express (for example collapsing an embedded sub-object to its id).
+
+    The view applies the shaping explicitly, immediately before building the
+    response::
+
+        class EnrollmentViewSet(MinimalViewMixin, viewsets.ViewSet):
+            minimal_fields = ("course_id", "mode", "is_active")
+
+            def list(self, request):
+                data = self.get_serializer(items, many=True).data
+                return Response(self.shape_minimal(data, request))
+
+    The default response shape is returned unchanged unless the client sends
+    ``?view=minimal`` (both the parameter name and value are overridable via
+    :attr:`minimal_view_query_param` and :attr:`minimal_view_value`).
+    """
+
+    #: Query parameter that selects the response preset.
+    minimal_view_query_param = "view"
+    #: Parameter value that selects the minimal preset.
+    minimal_view_value = "minimal"
+    #: Top-level fields kept by the default :meth:`to_minimal_representation`.
+    #: Views that need a non-projection shape override the method instead.
+    minimal_fields = None
+
+    def is_minimal_view_requested(self, request=None):
+        """Return True when the caller asked for the minimal preset."""
+        request = request if request is not None else self.request
+        params = getattr(request, "query_params", request.GET)
+        return params.get(self.minimal_view_query_param) == self.minimal_view_value
+
+    def to_minimal_representation(self, item):
+        """
+        Return the minimal representation of one serialized object.
+
+        Defaults to projecting ``item`` onto :attr:`minimal_fields`; raises
+        ``ImproperlyConfigured`` when the view configured neither the fields
+        nor an override, so a requested minimal view never silently returns
+        the full payload.
+        """
+        if self.minimal_fields is None:
+            raise ImproperlyConfigured(
+                f"{type(self).__name__} uses MinimalViewMixin but defines neither 'minimal_fields' "
+                f"nor a 'to_minimal_representation' override."
+            )
+        return project(item, self.minimal_fields)
+
+    def shape_minimal(self, data, request=None):
+        """
+        Apply the minimal representation to ``data`` when the client asked for it.
+
+        ``data`` may be one serialized object (a dict) or a list of them; the
+        original is returned untouched when the minimal preset was not requested.
+        """
+        if not self.is_minimal_view_requested(request):
+            return data
+        if isinstance(data, list):
+            return [self.to_minimal_representation(item) for item in data]
+        return self.to_minimal_representation(data)

--- a/edx_rest_framework_extensions/testing.py
+++ b/edx_rest_framework_extensions/testing.py
@@ -1,0 +1,68 @@
+"""
+Test helpers for the Open edX REST API conventions.
+"""
+from edx_rest_framework_extensions.errors import ERROR_TYPE_BASE_URI, error_type_uri
+
+
+#: The keys every ADR 0029 error envelope must carry.
+REQUIRED_ERROR_ENVELOPE_FIELDS = ("type", "title", "status", "detail", "instance")
+
+#: Legacy edx-platform error keys (``DeveloperErrorViewMixin``) that must not
+#: leak into a standardized envelope.
+LEGACY_ERROR_FIELDS = ("developer_message", "error_code")
+
+
+def assert_error_envelope(response, expected_status=None, expected_type_slug=None):
+    """
+    Assert that ``response`` carries a well-formed ADR 0029 error envelope.
+
+    Checks that every required envelope field is present, that ``status``
+    inside the body matches the response's status code, that ``type`` is an
+    ``https://docs.openedx.org/errors/`` URI, that ``instance`` is the request
+    path (when the test client attached the request to the response), and that
+    no legacy ``DeveloperErrorViewMixin`` fields leak through.
+
+    Arguments:
+        response: a DRF test-client response (``response.data``) or any
+            response exposing ``json()``.
+        expected_status (int): when given, also assert the HTTP status code.
+        expected_type_slug (str): when given, also assert the exact error-type
+            slug (e.g. ``"authn"``, ``"not-found"``).
+
+    Returns:
+        dict: the decoded envelope, for any follow-up assertions.
+    """
+    if expected_status is not None:
+        assert response.status_code == expected_status, (
+            f"expected HTTP {expected_status}, got {response.status_code}"
+        )
+
+    data = getattr(response, "data", None)
+    if data is None:
+        data = response.json()
+
+    for field in REQUIRED_ERROR_ENVELOPE_FIELDS:
+        assert field in data, f"ADR 0029: missing envelope field '{field}' in {data!r}"
+
+    assert data["status"] == response.status_code, (
+        f"ADR 0029: envelope 'status' {data['status']!r} does not match "
+        f"response status {response.status_code}"
+    )
+    assert str(data["type"]).startswith(ERROR_TYPE_BASE_URI), (
+        f"ADR 0029: 'type' {data['type']!r} is not an {ERROR_TYPE_BASE_URI} URI"
+    )
+    if expected_type_slug is not None:
+        assert data["type"] == error_type_uri(expected_type_slug), (
+            f"ADR 0029: expected type '{error_type_uri(expected_type_slug)}', got {data['type']!r}"
+        )
+
+    wsgi_request = getattr(response, "wsgi_request", None)
+    if wsgi_request is not None:
+        assert data["instance"] == wsgi_request.path, (
+            f"ADR 0029: 'instance' {data['instance']!r} is not the request path {wsgi_request.path!r}"
+        )
+
+    for field in LEGACY_ERROR_FIELDS:
+        assert field not in data, f"ADR 0029: legacy field '{field}' must not appear in the envelope"
+
+    return data

--- a/edx_rest_framework_extensions/tests/test_errors.py
+++ b/edx_rest_framework_extensions/tests/test_errors.py
@@ -1,0 +1,256 @@
+""" Tests for the ADR 0029 standardized error-response building blocks. """
+from django.test import TestCase, override_settings
+from rest_framework.authentication import BasicAuthentication
+from rest_framework.exceptions import (
+    APIException,
+    AuthenticationFailed,
+    NotAuthenticated,
+    NotFound,
+    PermissionDenied,
+    Throttled,
+    ValidationError,
+)
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
+
+from edx_rest_framework_extensions import errors
+from edx_rest_framework_extensions.errors import (
+    ERROR_TYPE_BASE_URI,
+    Conflict,
+    ErrorResponseSerializer,
+    classify_error,
+    error_type_uri,
+    flatten_detail,
+    normalize_validation_errors,
+    register_error_type,
+    standardized_error_exception_handler,
+)
+from edx_rest_framework_extensions.mixins import StandardizedErrorMixin
+
+
+_REQUIRED_ENVELOPE_FIELDS = ("type", "title", "status", "detail", "instance")
+
+
+def _get_response_for(exc, path="/api/things/"):
+    """ Run ``exc`` through a StandardizedErrorMixin APIView and return the response. """
+
+    class _View(StandardizedErrorMixin, APIView):
+        # An authenticator with a WWW-Authenticate challenge, so DRF keeps
+        # NotAuthenticated/AuthenticationFailed at 401 instead of downgrading to 403.
+        authentication_classes = (BasicAuthentication,)
+        permission_classes = ()
+
+        def get(self, request):
+            raise exc
+
+    return _View.as_view()(APIRequestFactory().get(path))
+
+
+def _custom_base_handler(exc, context):  # pylint: disable=unused-argument
+    """ A settings-resolvable base handler used by the dependency-inversion tests. """
+    return Response({"detail": "handled by custom base"}, status=418)
+
+
+class StandardizedErrorHandlerEnvelopeTests(TestCase):
+    """ The envelope produced for each cataloged exception type. """
+
+    def _assert_envelope(self, response, expected_status, expected_slug, expected_title):
+        for field in _REQUIRED_ENVELOPE_FIELDS:
+            self.assertIn(field, response.data)
+        self.assertEqual(response.status_code, expected_status)
+        self.assertEqual(response.data["status"], expected_status)
+        self.assertEqual(response.data["type"], error_type_uri(expected_slug))
+        self.assertEqual(response.data["title"], expected_title)
+        self.assertEqual(response.data["instance"], "/api/things/")
+        self.assertEqual(response["Content-Type"], "application/json")
+
+    def test_not_authenticated(self):
+        response = _get_response_for(NotAuthenticated())
+        self._assert_envelope(response, 401, "authn", "Authentication Required")
+
+    def test_authentication_failed(self):
+        response = _get_response_for(AuthenticationFailed())
+        self._assert_envelope(response, 401, "authn", "Authentication Failed")
+
+    def test_permission_denied(self):
+        response = _get_response_for(PermissionDenied())
+        self._assert_envelope(response, 403, "authz", "Permission Denied")
+
+    def test_not_found(self):
+        response = _get_response_for(NotFound("no such thing"))
+        self._assert_envelope(response, 404, "not-found", "Not Found")
+        self.assertEqual(response.data["detail"], "no such thing")
+
+    def test_validation_error(self):
+        response = _get_response_for(ValidationError({"name": ["required"]}))
+        self._assert_envelope(response, 400, "validation", "Validation Error")
+        self.assertEqual(response.data["errors"], {"name": ["required"]})
+
+    def test_throttled(self):
+        response = _get_response_for(Throttled())
+        self._assert_envelope(response, 429, "rate-limited", "Too Many Requests")
+
+    def test_conflict(self):
+        response = _get_response_for(Conflict())
+        self._assert_envelope(response, 409, "conflict", "Conflict")
+
+    def test_cataloged_exception_subclass_inherits_slug_and_title(self):
+        class _MoreSpecificNotFound(NotFound):
+            pass
+
+        response = _get_response_for(_MoreSpecificNotFound())
+        self._assert_envelope(response, 404, "not-found", "Not Found")
+
+    def test_uncataloged_api_exception_is_internal(self):
+        response = _get_response_for(APIException())
+        self._assert_envelope(response, 500, "internal", "Internal Server Error")
+
+    def test_non_api_exception_yields_internal_envelope(self):
+        # DRF's base handler returns None for non-APIExceptions; the
+        # standardized handler still produces the internal 500 envelope.
+        response = _get_response_for(RuntimeError("boom"))
+        for field in _REQUIRED_ENVELOPE_FIELDS:
+            self.assertIn(field, response.data)
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(response.data["type"], error_type_uri("internal"))
+        self.assertEqual(response.data["instance"], "/api/things/")
+
+    def test_user_message_passthrough(self):
+        exc = NotFound("no such thing")
+        exc.user_message = "We could not find that."
+        response = _get_response_for(exc)
+        self.assertEqual(response.data["user_message"], "We could not find that.")
+
+    def test_no_user_message_key_when_absent(self):
+        response = _get_response_for(NotFound())
+        self.assertNotIn("user_message", response.data)
+
+    def test_no_legacy_fields(self):
+        response = _get_response_for(NotFound())
+        self.assertNotIn("developer_message", response.data)
+        self.assertNotIn("error_code", response.data)
+
+
+class BaseHandlerDependencyInversionTests(TestCase):
+    """ The STANDARDIZED_ERROR_BASE_HANDLER setting controls the delegate handler. """
+
+    @override_settings(EDX_DRF_EXTENSIONS={
+        "STANDARDIZED_ERROR_BASE_HANDLER":
+            "edx_rest_framework_extensions.tests.test_errors._custom_base_handler",
+    })
+    def test_dotted_path_base_handler(self):
+        response = _get_response_for(NotFound())
+        # The custom base handler supplied the status; the envelope reshaping
+        # still ran on top of its response.
+        self.assertEqual(response.status_code, 418)
+        self.assertEqual(response.data["detail"], "handled by custom base")
+        self.assertEqual(response.data["type"], error_type_uri("not-found"))
+
+    @override_settings(EDX_DRF_EXTENSIONS={
+        "STANDARDIZED_ERROR_BASE_HANDLER": _custom_base_handler,
+    })
+    def test_callable_base_handler(self):
+        response = _get_response_for(NotFound())
+        self.assertEqual(response.status_code, 418)
+        self.assertEqual(response.data["detail"], "handled by custom base")
+
+    def test_defaults_to_drf_handler(self):
+        response = _get_response_for(NotFound("gone"))
+        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.data["detail"], "gone")
+
+
+class ErrorTypeCatalogTests(TestCase):
+    """ error_type_uri, classify_error, and the register_error_type extension helper. """
+
+    def test_error_type_uri(self):
+        self.assertEqual(error_type_uri("authn"), ERROR_TYPE_BASE_URI + "authn")
+
+    def test_classify_unknown_exception(self):
+        self.assertEqual(classify_error(RuntimeError()), ("internal", "Internal Server Error"))
+
+    def test_register_error_type(self):
+        class Teapot(APIException):
+            status_code = 418
+            default_detail = "I'm a teapot."
+
+        registry_snapshot = list(errors._registered_error_types)  # pylint: disable=protected-access
+        try:
+            register_error_type(Teapot, "teapot", "I'm a Teapot")
+            self.assertEqual(classify_error(Teapot()), ("teapot", "I'm a Teapot"))
+
+            response = _get_response_for(Teapot())
+            self.assertEqual(response.status_code, 418)
+            self.assertEqual(response.data["type"], error_type_uri("teapot"))
+            self.assertEqual(response.data["title"], "I'm a Teapot")
+        finally:
+            errors._registered_error_types[:] = registry_snapshot  # pylint: disable=protected-access
+
+    def test_registration_takes_precedence_over_builtin_catalog(self):
+        class SpecialNotFound(NotFound):
+            pass
+
+        registry_snapshot = list(errors._registered_error_types)  # pylint: disable=protected-access
+        try:
+            register_error_type(SpecialNotFound, "special-not-found", "Special Not Found")
+            self.assertEqual(classify_error(SpecialNotFound()), ("special-not-found", "Special Not Found"))
+            # The cataloged base class is unaffected.
+            self.assertEqual(classify_error(NotFound()), ("not-found", "Not Found"))
+        finally:
+            errors._registered_error_types[:] = registry_snapshot  # pylint: disable=protected-access
+
+
+class EnvelopeFormatterTests(TestCase):
+    """ flatten_detail and normalize_validation_errors. """
+
+    def test_flatten_string(self):
+        self.assertEqual(flatten_detail("oops"), "oops")
+
+    def test_flatten_dict_with_detail(self):
+        self.assertEqual(flatten_detail({"detail": "oops"}), "oops")
+
+    def test_flatten_list(self):
+        self.assertEqual(flatten_detail(["first", "second"]), "first")
+
+    def test_flatten_other(self):
+        self.assertEqual(flatten_detail({"name": ["bad"]}), "{'name': ['bad']}")
+
+    def test_normalize_dict(self):
+        self.assertEqual(
+            normalize_validation_errors({"name": ["a", "b"], "age": "c"}),
+            {"name": ["a", "b"], "age": ["c"]},
+        )
+
+    def test_normalize_list(self):
+        self.assertEqual(normalize_validation_errors(["a"]), {"non_field_errors": ["a"]})
+
+    def test_normalize_scalar(self):
+        self.assertEqual(normalize_validation_errors("a"), {"non_field_errors": ["a"]})
+
+
+class ErrorResponseSerializerTests(TestCase):
+    """ The plain-DRF documentation serializer round-trips a real envelope. """
+
+    def test_serializes_full_envelope(self):
+        response = _get_response_for(ValidationError({"name": ["required"]}))
+        serializer = ErrorResponseSerializer(data=dict(response.data))
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_optional_fields_are_optional(self):
+        serializer = ErrorResponseSerializer(data={
+            "type": error_type_uri("internal"),
+            "title": "Internal Server Error",
+            "status": 500,
+            "detail": "An unexpected error occurred.",
+        })
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+
+class HandlerWithoutRequestContextTests(TestCase):
+    """ The handler tolerates a context with no request (no 'instance' key). """
+
+    def test_no_request_in_context(self):
+        response = standardized_error_exception_handler(NotFound(), {"request": None})
+        self.assertNotIn("instance", response.data)
+        self.assertEqual(response.data["type"], error_type_uri("not-found"))

--- a/edx_rest_framework_extensions/tests/test_mixins.py
+++ b/edx_rest_framework_extensions/tests/test_mixins.py
@@ -1,0 +1,47 @@
+""" Tests for the DRF view mixins. """
+from django.test import TestCase
+from rest_framework.exceptions import NotFound
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
+
+from edx_rest_framework_extensions.errors import (
+    error_type_uri,
+    standardized_error_exception_handler,
+)
+from edx_rest_framework_extensions.mixins import StandardizedErrorMixin
+
+
+class StandardizedErrorMixinTests(TestCase):
+    """ Tests for StandardizedErrorMixin. """
+
+    def test_get_exception_handler_returns_standardized_handler(self):
+        class _View(StandardizedErrorMixin, APIView):
+            pass
+
+        self.assertIs(_View().get_exception_handler(), standardized_error_exception_handler)
+
+    def test_view_scoping(self):
+        """ Only views carrying the mixin return the envelope. """
+
+        class _EnvelopedView(StandardizedErrorMixin, APIView):
+            authentication_classes = ()
+            permission_classes = ()
+
+            def get(self, request):
+                raise NotFound()
+
+        class _PlainView(APIView):
+            authentication_classes = ()
+            permission_classes = ()
+
+            def get(self, request):
+                raise NotFound()
+
+        request = APIRequestFactory().get("/api/things/")
+
+        enveloped = _EnvelopedView.as_view()(request)
+        self.assertEqual(enveloped.data["type"], error_type_uri("not-found"))
+
+        plain = _PlainView.as_view()(request)
+        self.assertNotIn("type", plain.data)
+        self.assertNotIn("instance", plain.data)

--- a/edx_rest_framework_extensions/tests/test_no_platform_imports.py
+++ b/edx_rest_framework_extensions/tests/test_no_platform_imports.py
@@ -1,0 +1,33 @@
+"""
+Guard test: this library must never import from edx-platform.
+
+Platform behavior reaches the library through settings and documented
+extension points only (for example ``STANDARDIZED_ERROR_BASE_HANDLER``).
+See edx-platform ADR ``docs/decisions/0039-extract-rest-api-reference-implementation``.
+"""
+import pathlib
+import re
+from unittest import TestCase
+
+
+_PACKAGE_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# Matches module-level or inline `import lms...` / `from cms... import ...`.
+_FORBIDDEN_IMPORT = re.compile(
+    r"^\s*(?:import|from)\s+(lms|cms|openedx|common|xmodule)\b",
+    re.MULTILINE,
+)
+
+
+class NoPlatformImportTests(TestCase):
+    """ Fails when any module in the package imports from edx-platform. """
+
+    def test_no_platform_imports(self):
+        violations = []
+        for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
+            for match in _FORBIDDEN_IMPORT.finditer(path.read_text(encoding="utf-8")):
+                violations.append(f"{path.relative_to(_PACKAGE_ROOT)}: {match.group(0).strip()}")
+        self.assertEqual(
+            violations, [],
+            "edx-drf-extensions must not import from edx-platform:\n" + "\n".join(violations),
+        )

--- a/edx_rest_framework_extensions/tests/test_paginators.py
+++ b/edx_rest_framework_extensions/tests/test_paginators.py
@@ -5,12 +5,15 @@ from unittest import TestCase
 from unittest.mock import MagicMock, Mock
 
 import ddt
+from django.core.exceptions import ImproperlyConfigured
 from django.http import Http404
 from django.test import RequestFactory
 from rest_framework import serializers
 
 from edx_rest_framework_extensions.paginators import (
+    IterablePaginationMixin,
     NamespacedPageNumberPagination,
+    paginate_manually,
     paginate_search_results,
 )
 
@@ -188,3 +191,84 @@ def get_object_range(page, page_size):
     start = min((page - 1) * page_size, max_id)
     end = min(start + page_size, max_id + 1)
     return list(range(start, end))
+
+
+class ManualPaginationTestCase(TestCase):
+    """ Test cases for paginate_manually() and IterablePaginationMixin. """
+
+    def setUp(self):
+        super().setUp()
+        self.items = [{'id': idx} for idx in range(25)]
+        self.request_factory = RequestFactory()
+
+    def _request(self, **params):
+        request = self.request_factory.get('/endpoint', data=params)
+        request.query_params = params
+        return request
+
+    def test_paginate_manually_default_pagination(self):
+        request = self._request(page=2, page_size=5)
+        response = paginate_manually(request, self.items, serialize=lambda page: page)
+
+        self.assertEqual(response.data['results'], self.items[5:10])
+        self.assertEqual(response.data['count'], 25)
+        self.assertEqual(response.data['num_pages'], 5)
+        self.assertEqual(response.data['current_page'], 2)
+        self.assertEqual(response.data['start'], 5)
+        self.assertIn('next', response.data)
+        self.assertIn('previous', response.data)
+
+    def test_paginate_manually_serialize_receives_only_the_page(self):
+        request = self._request(page=1, page_size=3)
+        seen = []
+        paginate_manually(request, self.items, serialize=lambda page: seen.append(list(page)))
+        self.assertEqual(seen, [self.items[:3]])
+
+    def test_paginate_manually_custom_pagination_class(self):
+        request = self._request(page=1, page_size=4)
+        response = paginate_manually(
+            request, self.items, serialize=lambda page: page,
+            pagination_class=NamespacedPageNumberPagination,
+        )
+        self.assertEqual(response.data['results'], self.items[:4])
+        self.assertEqual(response.data['pagination']['count'], 25)
+
+    def test_mixin_uses_get_serializer(self):
+        items = self.items
+
+        class _FakeSerializer:
+            """ Stand-in for a DRF serializer: uppercases nothing, wraps items. """
+            def __init__(self, page, many=False):
+                assert many
+                self.data = [{'wrapped': item['id']} for item in page]
+
+        class _View(IterablePaginationMixin):
+            def get_serializer(self, page, many=False):
+                return _FakeSerializer(page, many=many)
+
+        response = _View().paginate_iterable(self._request(page=1, page_size=2), items)
+        self.assertEqual(response.data['results'], [{'wrapped': 0}, {'wrapped': 1}])
+        self.assertEqual(response.data['count'], 25)
+
+    def test_mixin_explicit_serialize_argument(self):
+        class _View(IterablePaginationMixin):
+            pass
+
+        response = _View().paginate_iterable(
+            self._request(page=1, page_size=2), self.items, serialize=list,
+        )
+        self.assertEqual(response.data['results'], self.items[:2])
+
+    def test_mixin_without_serializer_or_serialize_raises(self):
+        class _View(IterablePaginationMixin):
+            pass
+
+        with self.assertRaises(ImproperlyConfigured):
+            _View().paginate_iterable(self._request(page=1), self.items)
+
+    def test_mixin_with_none_pagination_class_raises(self):
+        class _View(IterablePaginationMixin):
+            pagination_class = None
+
+        with self.assertRaises(ImproperlyConfigured):
+            _View().paginate_iterable(self._request(page=1), self.items, serialize=list)

--- a/edx_rest_framework_extensions/tests/test_routers.py
+++ b/edx_rest_framework_extensions/tests/test_routers.py
@@ -1,0 +1,54 @@
+""" Tests for the opaque-key lookup regex constants. """
+import re
+from unittest import TestCase
+
+import ddt
+
+from edx_rest_framework_extensions.routers import (
+    COURSE_KEY_LOOKUP_REGEX,
+    USAGE_KEY_LOOKUP_REGEX,
+)
+
+
+@ddt.ddt
+class CourseKeyLookupRegexTests(TestCase):
+    """ COURSE_KEY_LOOKUP_REGEX delimits both course-key styles. """
+
+    @ddt.data(
+        "course-v1:edX+DemoX+Demo_2024",       # new style
+        "course-v1:edX+DemoX+Demo_2024.1",     # dot in the run
+        "edX/DemoX/Demo_2014",                 # old style
+        "ccx-v1:edX+DemoX+Demo_2024+ccx@1",    # CCX key
+    )
+    def test_matches(self, value):
+        self.assertIsNotNone(re.fullmatch(COURSE_KEY_LOOKUP_REGEX, value))
+
+    @ddt.data(
+        "edX",              # no separators at all
+        "edX+DemoX",        # only one separator
+        "a/b/c/d",          # trailing slash-separated extra segment
+        "a+b+c?x=1",        # query separator inside the run
+    )
+    def test_rejects(self, value):
+        self.assertIsNone(re.fullmatch(COURSE_KEY_LOOKUP_REGEX, value))
+
+
+@ddt.ddt
+class UsageKeyLookupRegexTests(TestCase):
+    """ USAGE_KEY_LOOKUP_REGEX delimits both usage-key styles. """
+
+    @ddt.data(
+        "block-v1:edX+DemoX+Demo_2024+type@problem+block@abc123",  # new style
+        "lb:edX:DemoX:problem:abc123",                             # learning-core style
+        "i4x://edX/DemoX/problem/abc123",                          # old style
+        "i4x://edX/DemoX/problem/abc123@draft",                    # old style with revision
+    )
+    def test_matches(self, value):
+        self.assertIsNotNone(re.fullmatch(USAGE_KEY_LOOKUP_REGEX, value))
+
+    @ddt.data(
+        "edX/DemoX/problem",     # bare slashes without the i4x prefix
+        "",                      # empty
+    )
+    def test_rejects(self, value):
+        self.assertIsNone(re.fullmatch(USAGE_KEY_LOOKUP_REGEX, value))

--- a/edx_rest_framework_extensions/tests/test_shaping.py
+++ b/edx_rest_framework_extensions/tests/test_shaping.py
@@ -1,0 +1,102 @@
+""" Tests for the ADR 0036 response-shaping helpers. """
+from unittest import TestCase
+from unittest.mock import Mock
+
+from django.core.exceptions import ImproperlyConfigured
+
+from edx_rest_framework_extensions.shaping import MinimalViewMixin, project
+
+
+class ProjectTests(TestCase):
+    """ Tests for project(). """
+
+    def setUp(self):
+        super().setUp()
+        self.data = {"id": 1, "name": "thing", "children": [2, 3], "heavy": {"x": 1}}
+
+    def test_csv_string(self):
+        self.assertEqual(project(self.data, "id,name"), {"id": 1, "name": "thing"})
+
+    def test_iterable(self):
+        self.assertEqual(project(self.data, ["id", "heavy"]), {"id": 1, "heavy": {"x": 1}})
+
+    def test_whitespace_and_empty_names_ignored(self):
+        self.assertEqual(project(self.data, " id , ,name "), {"id": 1, "name": "thing"})
+
+    def test_dotted_paths_stripped_to_first_segment(self):
+        self.assertEqual(project(self.data, "children.x"), {"children": [2, 3]})
+
+    def test_unknown_fields_yield_empty_dict(self):
+        self.assertEqual(project(self.data, "nope"), {})
+
+    def test_falsy_fields_returns_data_unchanged(self):
+        self.assertIs(project(self.data, None), self.data)
+        self.assertIs(project(self.data, ""), self.data)
+        self.assertIs(project(self.data, []), self.data)
+
+    def test_only_whitespace_names_returns_data_unchanged(self):
+        self.assertIs(project(self.data, " , "), self.data)
+
+    def test_non_dict_data_returned_untouched(self):
+        self.assertEqual(project([1, 2], "id"), [1, 2])
+        self.assertEqual(project("text", "id"), "text")
+
+    def test_returns_new_dict(self):
+        result = project(self.data, "id,name,children,heavy")
+        self.assertEqual(result, self.data)
+        self.assertIsNot(result, self.data)
+
+
+class MinimalViewMixinTests(TestCase):
+    """ Tests for MinimalViewMixin. """
+
+    def _make_view(self, query_params, **attrs):
+        view = type("_View", (MinimalViewMixin,), attrs)()
+        view.request = Mock(query_params=query_params)
+        return view
+
+    def test_is_minimal_view_requested(self):
+        self.assertTrue(self._make_view({"view": "minimal"}).is_minimal_view_requested())
+        self.assertFalse(self._make_view({"view": "full"}).is_minimal_view_requested())
+        self.assertFalse(self._make_view({}).is_minimal_view_requested())
+
+    def test_not_requested_returns_data_unchanged(self):
+        view = self._make_view({}, minimal_fields=("id",))
+        data = [{"id": 1, "heavy": "x"}]
+        self.assertIs(view.shape_minimal(data), data)
+
+    def test_requested_projects_each_list_item(self):
+        view = self._make_view({"view": "minimal"}, minimal_fields=("id",))
+        data = [{"id": 1, "heavy": "x"}, {"id": 2, "heavy": "y"}]
+        self.assertEqual(view.shape_minimal(data), [{"id": 1}, {"id": 2}])
+
+    def test_requested_projects_single_object(self):
+        view = self._make_view({"view": "minimal"}, minimal_fields=("id",))
+        self.assertEqual(view.shape_minimal({"id": 1, "heavy": "x"}), {"id": 1})
+
+    def test_custom_representation_override(self):
+        def to_minimal(self, item):  # pylint: disable=unused-argument
+            return {"course_id": item["course_details"]["course_id"]}
+
+        view = self._make_view({"view": "minimal"}, to_minimal_representation=to_minimal)
+        data = [{"mode": "audit", "course_details": {"course_id": "course-v1:a+b+c", "modes": []}}]
+        self.assertEqual(view.shape_minimal(data), [{"course_id": "course-v1:a+b+c"}])
+
+    def test_unconfigured_view_raises_when_minimal_requested(self):
+        view = self._make_view({"view": "minimal"})
+        with self.assertRaises(ImproperlyConfigured):
+            view.shape_minimal([{"id": 1}])
+
+    def test_custom_parameter_name_and_value(self):
+        view = self._make_view(
+            {"preset": "tiny"},
+            minimal_view_query_param="preset",
+            minimal_view_value="tiny",
+            minimal_fields=("id",),
+        )
+        self.assertEqual(view.shape_minimal({"id": 1, "heavy": "x"}), {"id": 1})
+
+    def test_explicit_request_argument_wins(self):
+        view = self._make_view({}, minimal_fields=("id",))
+        other_request = Mock(query_params={"view": "minimal"})
+        self.assertEqual(view.shape_minimal({"id": 1, "heavy": "x"}, other_request), {"id": 1})

--- a/edx_rest_framework_extensions/tests/test_testing.py
+++ b/edx_rest_framework_extensions/tests/test_testing.py
@@ -1,0 +1,108 @@
+""" Tests for the REST API convention test helpers. """
+from types import SimpleNamespace
+from unittest import TestCase
+
+from rest_framework.exceptions import NotFound, ValidationError
+from rest_framework.test import APIRequestFactory
+from rest_framework.views import APIView
+
+from edx_rest_framework_extensions.errors import error_type_uri
+from edx_rest_framework_extensions.mixins import StandardizedErrorMixin
+from edx_rest_framework_extensions.testing import assert_error_envelope
+
+
+def _real_envelope_response(exc, path="/api/things/"):
+    """ Produce a real envelope response through a StandardizedErrorMixin view. """
+
+    class _View(StandardizedErrorMixin, APIView):
+        authentication_classes = ()
+        permission_classes = ()
+
+        def get(self, request):
+            raise exc
+
+    return _View.as_view()(APIRequestFactory().get(path))
+
+
+def _fake_response(data, status_code=404, **attrs):
+    """ Build a minimal response-like object carrying ``data``. """
+    return SimpleNamespace(data=data, status_code=status_code, **attrs)
+
+
+class AssertErrorEnvelopeTests(TestCase):
+    """ Tests for assert_error_envelope(). """
+
+    def test_passes_on_real_envelope(self):
+        response = _real_envelope_response(NotFound("gone"))
+        data = assert_error_envelope(response, expected_status=404, expected_type_slug="not-found")
+        self.assertEqual(data["detail"], "gone")
+
+    def test_passes_on_validation_envelope(self):
+        response = _real_envelope_response(ValidationError({"name": ["required"]}))
+        data = assert_error_envelope(response, expected_status=400, expected_type_slug="validation")
+        self.assertEqual(data["errors"], {"name": ["required"]})
+
+    def test_fails_on_wrong_status(self):
+        response = _real_envelope_response(NotFound())
+        with self.assertRaisesRegex(AssertionError, "expected HTTP 401"):
+            assert_error_envelope(response, expected_status=401)
+
+    def test_fails_on_wrong_type_slug(self):
+        response = _real_envelope_response(NotFound())
+        with self.assertRaisesRegex(AssertionError, "expected type"):
+            assert_error_envelope(response, expected_type_slug="authz")
+
+    def test_fails_on_missing_required_field(self):
+        response = _fake_response({
+            "type": error_type_uri("not-found"),
+            "title": "Not Found",
+            "status": 404,
+            "detail": "gone",
+            # no "instance"
+        })
+        with self.assertRaisesRegex(AssertionError, "missing envelope field 'instance'"):
+            assert_error_envelope(response)
+
+    def test_fails_on_status_mismatch_between_body_and_response(self):
+        response = _fake_response(
+            {"type": error_type_uri("not-found"), "title": "x", "status": 400,
+             "detail": "d", "instance": "/p"},
+            status_code=404,
+        )
+        with self.assertRaisesRegex(AssertionError, "does not match"):
+            assert_error_envelope(response)
+
+    def test_fails_on_non_catalog_type_uri(self):
+        response = _fake_response(
+            {"type": "https://example.com/errors/other", "title": "x", "status": 404,
+             "detail": "d", "instance": "/p"},
+            status_code=404,
+        )
+        with self.assertRaisesRegex(AssertionError, "is not an"):
+            assert_error_envelope(response)
+
+    def test_fails_on_legacy_fields(self):
+        response = _fake_response(
+            {"type": error_type_uri("not-found"), "title": "x", "status": 404,
+             "detail": "d", "instance": "/p", "developer_message": "leak"},
+            status_code=404,
+        )
+        with self.assertRaisesRegex(AssertionError, "legacy field 'developer_message'"):
+            assert_error_envelope(response)
+
+    def test_fails_on_instance_not_matching_request_path(self):
+        response = _fake_response(
+            {"type": error_type_uri("not-found"), "title": "x", "status": 404,
+             "detail": "d", "instance": "/other/"},
+            status_code=404,
+            wsgi_request=SimpleNamespace(path="/api/things/"),
+        )
+        with self.assertRaisesRegex(AssertionError, "is not the request path"):
+            assert_error_envelope(response)
+
+    def test_falls_back_to_json_method(self):
+        body = {"type": error_type_uri("authn"), "title": "Authentication Required",
+                "status": 401, "detail": "d", "instance": "/p"}
+        response = SimpleNamespace(status_code=401, json=lambda: body)
+        data = assert_error_envelope(response, expected_type_slug="authn")
+        self.assertEqual(data, body)

--- a/edx_rest_framework_extensions/tests/test_url_converters.py
+++ b/edx_rest_framework_extensions/tests/test_url_converters.py
@@ -1,0 +1,174 @@
+"""
+Tests for the shared opaque-key URL path converters (edx-platform ADR 0038).
+
+The integration tests pin the behaviour the ADR's "Code examples" section
+records as verified: non-deprecated keys resolve and ``reverse()`` round-trips
+them, deprecated and malformed keys both 404, and two converters can appear in
+one route.
+"""
+import re
+from unittest import TestCase
+
+import pytest
+from django.http import HttpResponse
+from django.test import SimpleTestCase, override_settings
+from django.urls import NoReverseMatch, Resolver404, path, resolve, reverse
+from opaque_keys.edx.keys import CourseKey, UsageKey
+
+from edx_rest_framework_extensions.url_converters import (
+    CourseKeyConverter,
+    UsageKeyConverter,
+    register_url_converters,
+)
+
+
+COURSE_KEY = "course-v1:edX+DemoX+Demo_2024"
+CCX_KEY = "ccx-v1:edX+DemoX+Demo_2024+ccx@1"
+USAGE_KEY = "block-v1:edX+DemoX+Demo_2024+type@problem+block@abc123"
+DEPRECATED_COURSE_KEY = "edX/DemoX/Demo_2014"
+DEPRECATED_USAGE_KEY = "i4x://edX/DemoX/problem/abc123"
+
+
+def _dummy_view(request, **kwargs):  # pylint: disable=unused-argument  # pragma: no cover - never called
+    return HttpResponse()
+
+
+# An isolated URLconf exercising the converters, including two in one route.
+register_url_converters()
+
+urlpatterns = [
+    path(
+        "api/course/v1/courses/<course_key:course_key>/",
+        _dummy_view,
+        name="course_detail",
+    ),
+    path(
+        "api/authoring/v1/xblocks/<usage_key:usage_key>/",
+        _dummy_view,
+        name="xblock_detail",
+    ),
+    path(
+        "api/course/v1/courses/<course_key:course_key>/blocks/<usage_key:usage_key>/",
+        _dummy_view,
+        name="course_block_detail",
+    ),
+]
+
+
+class CourseKeyConverterTests(TestCase):
+    """ Unit tests for CourseKeyConverter. """
+
+    def setUp(self):
+        super().setUp()
+        self.converter = CourseKeyConverter()
+
+    def test_to_python_parses_course_v1_key(self):
+        key = self.converter.to_python(COURSE_KEY)
+        self.assertIsInstance(key, CourseKey)
+        self.assertEqual(str(key), COURSE_KEY)
+
+    def test_to_python_parses_ccx_key(self):
+        # CCX keys are registered by the optional ``ccx-keys`` package (an
+        # opaque-keys entry point); the converter accepts whichever key types
+        # the host service has installed.
+        pytest.importorskip("ccx_keys")
+        self.assertIsInstance(self.converter.to_python(CCX_KEY), CourseKey)
+
+    def test_to_python_rejects_malformed_key(self):
+        # ValueError → Django treats the route as not matching → 404.
+        with pytest.raises(ValueError):
+            self.converter.to_python("not-a-course-key")
+
+    def test_to_python_rejects_deprecated_key(self):
+        # Org/Course/Run keys are Old Mongo-only and rejected on conforming
+        # routes (ADR 0038 rule 9). The '/' means such a key can also never
+        # match the regex within a single path segment.
+        self.assertTrue(CourseKey.from_string(DEPRECATED_COURSE_KEY).deprecated)
+        with pytest.raises(ValueError):
+            self.converter.to_python(DEPRECATED_COURSE_KEY)
+
+    def test_to_url_round_trips(self):
+        key = CourseKey.from_string(COURSE_KEY)
+        self.assertEqual(self.converter.to_url(key), COURSE_KEY)
+
+    def test_regex_excludes_slash(self):
+        self.assertIsNone(re.fullmatch(self.converter.regex, DEPRECATED_COURSE_KEY))
+        self.assertIsNotNone(re.fullmatch(self.converter.regex, COURSE_KEY))
+
+
+class UsageKeyConverterTests(TestCase):
+    """ Unit tests for UsageKeyConverter. """
+
+    def setUp(self):
+        super().setUp()
+        self.converter = UsageKeyConverter()
+
+    def test_to_python_parses_block_v1_key(self):
+        key = self.converter.to_python(USAGE_KEY)
+        self.assertIsInstance(key, UsageKey)
+        self.assertEqual(str(key), USAGE_KEY)
+
+    def test_to_python_rejects_malformed_key(self):
+        with pytest.raises(ValueError):
+            self.converter.to_python("not-a-usage-key")
+
+    def test_to_python_rejects_deprecated_key(self):
+        self.assertTrue(UsageKey.from_string(DEPRECATED_USAGE_KEY).deprecated)
+        with pytest.raises(ValueError):
+            self.converter.to_python(DEPRECATED_USAGE_KEY)
+
+    def test_to_url_round_trips(self):
+        key = UsageKey.from_string(USAGE_KEY)
+        self.assertEqual(self.converter.to_url(key), USAGE_KEY)
+
+
+@override_settings(ROOT_URLCONF=__name__)
+class UrlConverterIntegrationTests(SimpleTestCase):
+    """ resolve()/reverse() behaviour of the registered converters. """
+
+    def test_resolve_passes_parsed_course_key_to_the_view(self):
+        match = resolve(f"/api/course/v1/courses/{COURSE_KEY}/")
+        self.assertEqual(match.url_name, "course_detail")
+        self.assertIsInstance(match.kwargs["course_key"], CourseKey)
+        self.assertEqual(str(match.kwargs["course_key"]), COURSE_KEY)
+
+    def test_resolve_passes_parsed_usage_key_to_the_view(self):
+        match = resolve(f"/api/authoring/v1/xblocks/{USAGE_KEY}/")
+        self.assertEqual(match.url_name, "xblock_detail")
+        self.assertIsInstance(match.kwargs["usage_key"], UsageKey)
+
+    def test_two_converters_can_appear_in_one_route(self):
+        match = resolve(f"/api/course/v1/courses/{COURSE_KEY}/blocks/{USAGE_KEY}/")
+        self.assertEqual(match.url_name, "course_block_detail")
+        self.assertIsInstance(match.kwargs["course_key"], CourseKey)
+        self.assertIsInstance(match.kwargs["usage_key"], UsageKey)
+
+    def test_malformed_course_key_is_404(self):
+        with pytest.raises(Resolver404):
+            resolve("/api/course/v1/courses/not-a-course-key/")
+
+    def test_deprecated_usage_key_is_404(self):
+        # The deprecated form contains '/', so it cannot even match the
+        # single-segment regex; a slashless-but-deprecated spelling is
+        # rejected by to_python. Either way: 404.
+        with pytest.raises(Resolver404):
+            resolve(f"/api/authoring/v1/xblocks/{DEPRECATED_USAGE_KEY}/")
+
+    def test_reverse_round_trips_a_parsed_key(self):
+        url = reverse(
+            "course_detail",
+            kwargs={"course_key": CourseKey.from_string(COURSE_KEY)},
+        )
+        self.assertEqual(url, f"/api/course/v1/courses/{COURSE_KEY}/")
+
+    def test_reverse_accepts_the_string_form(self):
+        url = reverse("xblock_detail", kwargs={"usage_key": USAGE_KEY})
+        self.assertEqual(url, f"/api/authoring/v1/xblocks/{USAGE_KEY}/")
+
+    def test_reverse_rejects_a_deprecated_key(self):
+        # str(deprecated key) contains '/', which fails the converter regex.
+        with pytest.raises(NoReverseMatch):
+            reverse(
+                "course_detail",
+                kwargs={"course_key": CourseKey.from_string(DEPRECATED_COURSE_KEY)},
+            )

--- a/edx_rest_framework_extensions/url_converters.py
+++ b/edx_rest_framework_extensions/url_converters.py
@@ -1,0 +1,95 @@
+"""
+Shared opaque-key URL path converters (edx-platform ADR 0038).
+
+edx-platform ADR 0038 ("Standardize REST API URL Structure") rule 9 requires
+identifiers on conforming API URLs to be opaque keys resolved by shared path
+converters, so that views receive parsed keys and a malformed key becomes a
+consistent 404 rather than an ad-hoc 400::
+
+    # urls.py — once per service, before any pattern using the converters
+    from edx_rest_framework_extensions.url_converters import register_url_converters
+    register_url_converters()
+
+    urlpatterns = [
+        path(
+            "api/course/v1/courses/<course_key:course_key>/",
+            CourseView.as_view(),
+            name="course_detail",
+        ),
+    ]
+
+New and migrated APIs accept only non-deprecated keys (``course-v1:``,
+``ccx-v1:``, ``block-v1:`` …). Deprecated ``Org/Course/Run`` and ``i4x://``
+forms contain ``/`` and exist only for pre-existing Old Mongo content, which
+conforming routes do not serve; the converters reject them in ``to_python``,
+which Django turns into a 404. Because only non-deprecated keys are accepted,
+the regex is simply "no slash" rather than a transcription of the permissive
+platform patterns — endpoints that must keep serving Old Mongo content should
+keep their slash-tolerant ``re_path`` routes (or, for router-registered
+ViewSets, the :mod:`~edx_rest_framework_extensions.routers` lookup regexes)
+instead of these converters.
+"""
+
+from django.urls import register_converter
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey, UsageKey
+
+
+class CourseKeyConverter:
+    """
+    Match non-deprecated course run keys (``course-v1:``, ``ccx-v1:``).
+
+    Views receive a parsed :class:`~opaque_keys.edx.keys.CourseKey`;
+    ``reverse()`` accepts a ``CourseKey`` (or its string form).
+    """
+
+    regex = r'[^/]+'
+
+    def to_python(self, value: str) -> CourseKey:
+        """ Parse ``value``; raise ``ValueError`` (→ 404) if invalid or deprecated. """
+        try:
+            course_key = CourseKey.from_string(value)
+        except InvalidKeyError as exc:
+            raise ValueError from exc          # Django turns this into a 404
+        if course_key.deprecated:              # Org/Course/Run — Old Mongo only
+            raise ValueError(f"deprecated course key: {value}")
+        return course_key
+
+    def to_url(self, value: CourseKey) -> str:
+        """ Serialize for ``reverse()``. """
+        return str(value)
+
+
+class UsageKeyConverter:
+    """
+    Match non-deprecated usage keys (``block-v1:``, ``lb:``, …).
+
+    Views receive a parsed :class:`~opaque_keys.edx.keys.UsageKey`;
+    ``reverse()`` accepts a ``UsageKey`` (or its string form).
+    """
+
+    regex = r'[^/]+'
+
+    def to_python(self, value: str) -> UsageKey:
+        """ Parse ``value``; raise ``ValueError`` (→ 404) if invalid or deprecated. """
+        try:
+            usage_key = UsageKey.from_string(value)
+        except InvalidKeyError as exc:
+            raise ValueError from exc          # Django turns this into a 404
+        if usage_key.deprecated:               # i4x:// — Old Mongo only
+            raise ValueError(f"deprecated usage key: {value}")
+        return usage_key
+
+    def to_url(self, value: UsageKey) -> str:
+        """ Serialize for ``reverse()``. """
+        return str(value)
+
+
+def register_url_converters():
+    """
+    Register the shared converters under the names ``course_key`` and
+    ``usage_key``. Call once per service, from the project URLconf, before
+    any URL pattern that uses ``<course_key:...>`` or ``<usage_key:...>``.
+    """
+    register_converter(CourseKeyConverter, "course_key")
+    register_converter(UsageKeyConverter, "usage_key")


### PR DESCRIPTION
Adds the reusable core of the FC-0118 REST API conventions work to this library, as discussed in the OEP-69 review (https://github.com/openedx/openedx-proposals/pull/805#discussion_r2214477751). Until now the reference implementation was split: pagination and JWT auth live here, but the error envelope, response shaping, and test helpers live inside edx-platform where plugins and other IDAs can't reach them. This PR moves the pieces that were agreed as feasible to extract without dragging platform coupling along:

errors.py: the ADR 0029 standardized error envelope: standardized_error_exception_handler, the Conflict (409) exception, the envelope formatters, the error-type URI catalog with a register_error_type extension helper, and a plain-DRF ErrorResponseSerializer for documenting error responses in OpenAPI schemas.
mixins.py: StandardizedErrorMixin, the per-view opt-in for the handler.
shaping.py: ADR 0036 response shaping: project() for ?fields= top-level field selection and MinimalViewMixin for the ?view=minimal preset.
paginators.py (existing): paginate_manually() and IterablePaginationMixin, so endpoints outside DRF's generic list machinery can return the ADR 0032 envelope without hand-writing the paginate/serialize/respond sequence.
routers.py: opaque-key lookup_value_regex constants (COURSE_KEY_LOOKUP_REGEX, USAGE_KEY_LOOKUP_REGEX), which every router-registered ViewSet keyed by an opaque key currently hand-writes.
url_converters.py: the ADR 0038 (URL structure standardization) shared Django path converters: CourseKeyConverter and UsageKeyConverter, registered once per service via register_url_converters() as <course_key:...> / <usage_key:...>. Conforming routes resolve opaque keys in the URLconf, views receive parsed keys, and malformed or deprecated (Org/Course/Run, i4x://) keys become routing-level 404s. Extracted here per the ADR's "Code examples" section and the ADR review request (openedx/openedx-platform#39003 (comment) — https://github.com/openedx/openedx-platform/pull/39003#discussion_r3833688640); non-deprecated-key APIs use the converters, while endpoints that must keep serving Old Mongo content keep the permissive routers.py lookup regexes. Behaviour verified identical to the edx-platform copy it replaces, on Django 4.2 and 5.2.
testing.py: assert_error_envelope(), one assertion for consumer test suites instead of the per-field loops the pilot tests repeat.
The one real obstacle was the handler's import of ignored_error_exception_handler from platform internals. That coupling is now inverted: the handler delegates to a base handler resolved from a new EDX_DRF_EXTENSIONS['STANDARDIZED_ERROR_BASE_HANDLER'] setting (dotted path or callable, defaulting to DRF's own exception_handler), so edx-platform keeps its error monitoring purely through configuration. A guard test enforces that nothing in this package imports from edx-platform.

No new dependencies (url_converters depends only on edx-opaque-keys, already in base.in). Bumps version to 10.8.0.